### PR TITLE
Feature improve readability

### DIFF
--- a/Baya/layouts/BayaEqualSegmentsLayout.swift
+++ b/Baya/layouts/BayaEqualSegmentsLayout.swift
@@ -119,7 +119,7 @@ extension Sequence where Iterator.Element: BayaLayoutable {
     /**
         Distributes the available size evenly.
     */
-    func layoutEqualSegments(
+    func layoutAsEqualSegments(
         orientation: BayaLayoutOptions.Orientation,
         gutter: CGFloat = 0,
         layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)
@@ -136,7 +136,7 @@ extension Sequence where Iterator.Element == BayaLayoutable {
     /**
         Distributes the available size evenly.
     */
-    func layoutEqualSegments(
+    func layoutAsEqualSegments(
         orientation: BayaLayoutOptions.Orientation,
         gutter: CGFloat = 0,
         layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)

--- a/Baya/layouts/BayaFixedSizeLayout.swift
+++ b/Baya/layouts/BayaFixedSizeLayout.swift
@@ -46,7 +46,7 @@ public extension BayaLayoutable {
     /**
         Gives this element a fixed sized container.
     */
-    func layoutFixedSize(
+    func layoutWithFixedSize(
         width: CGFloat?,
         height: CGFloat?,
         layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)

--- a/Baya/layouts/BayaFlexibleContentLayout.swift
+++ b/Baya/layouts/BayaFlexibleContentLayout.swift
@@ -7,7 +7,9 @@ import Foundation
 import UIKit
 
 /**
-    A Layout that stretches a Layoutable to fill the available space.
+    A layout that subtracts the frames of two optional elements before laying out its content element.
+    First the elements before and after the content will be measured and positioned, then the content
+    element will be measured and positioned with the remaining space.
  */
 public struct FlexibleContentLayout: BayaLayout {
     public var layoutMargins: UIEdgeInsets
@@ -153,15 +155,15 @@ public struct FlexibleContentLayout: BayaLayout {
 }
 
 public extension BayaLayoutable {
-    func layoutFlexibleContent(
-        orientation: BayaLayoutOptions.Orientation,
-        before: BayaLayoutable? = nil,
-        after: BayaLayoutable? = nil,
+    func layoutFlexible(
+        elementBefore: BayaLayoutable? = nil,
+        elementAfter: BayaLayoutable? = nil,
+        orientation: BayaLayoutOptions.Orientation = .horizontal,
         spacing: Int = 0,
         layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)
             -> FlexibleContentLayout {
         return FlexibleContentLayout(
-            elements: (before:  before, content: self, after: after),
+            elements: (before:  elementBefore, content: self, after: elementAfter),
             orientation: orientation,
             spacing: spacing,
             layoutMargins: layoutMargins)

--- a/Baya/layouts/BayaFrameLayout.swift
+++ b/Baya/layouts/BayaFrameLayout.swift
@@ -55,7 +55,7 @@ extension Sequence where Iterator.Element: BayaLayoutable {
     /**
         Groups the layoutables together.
     */
-    func layoutFrame(layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaFrameLayout {
+    func layoutAsFrame(layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaFrameLayout {
         return BayaFrameLayout(elements: self.array(), layoutMargins: layoutMargins)
     }
 }
@@ -64,7 +64,7 @@ extension Sequence where Iterator.Element == BayaLayoutable {
     /**
         Groups the layoutables together.
     */
-    func layoutFrame(layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaFrameLayout {
+    func layoutAsFrame(layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaFrameLayout {
         return BayaFrameLayout(elements: self.array(), layoutMargins: layoutMargins)
     }
 }

--- a/Baya/layouts/BayaGravityLayout.swift
+++ b/Baya/layouts/BayaGravityLayout.swift
@@ -56,19 +56,19 @@ public struct BayaGravityLayout: BayaLayout {
 }
 
 public extension BayaLayoutable {
-    func layoutGravity(to horizontalGravity: BayaLayoutOptions.Gravity.Horizontal) -> BayaGravityLayout {
+    func layoutGravitating(to horizontalGravity: BayaLayoutOptions.Gravity.Horizontal) -> BayaGravityLayout {
         return BayaGravityLayout(
             element: self,
             gravity: (horizontalGravity, .top))
     }
 
-    func layoutGravity(to verticalGravity: BayaLayoutOptions.Gravity.Vertical) -> BayaGravityLayout {
+    func layoutGravitating(to verticalGravity: BayaLayoutOptions.Gravity.Vertical) -> BayaGravityLayout {
         return BayaGravityLayout(
             element: self,
             gravity: (.left, verticalGravity))
     }
 
-    func layoutGravity(
+    func layoutGravitating(
         horizontally horizontalGravity: BayaLayoutOptions.Gravity.Horizontal,
         vertically verticalGravity: BayaLayoutOptions.Gravity.Vertical,
         layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)

--- a/Baya/layouts/BayaLinearLayout.swift
+++ b/Baya/layouts/BayaLinearLayout.swift
@@ -156,7 +156,7 @@ extension Sequence where Iterator.Element: BayaLayoutable {
     /**
         Creates a linear layout.
     */
-    func layoutLinear(
+    func layoutLinearly(
         orientation: BayaLayoutOptions.Orientation,
         direction: BayaLayoutOptions.Direction = .normal,
         layoutMargins: UIEdgeInsets = UIEdgeInsets.zero,
@@ -175,7 +175,7 @@ extension Sequence where Iterator.Element == BayaLayoutable {
     /**
         Creates a linear layout.
     */
-    func layoutLinear(
+    func layoutLinearly(
         orientation: BayaLayoutOptions.Orientation,
         direction: BayaLayoutOptions.Direction = .normal,
         layoutMargins: UIEdgeInsets = UIEdgeInsets.zero,

--- a/Baya/layouts/BayaMatchParentLayout.swift
+++ b/Baya/layouts/BayaMatchParentLayout.swift
@@ -43,7 +43,7 @@ public struct BayaMatchParentLayout: BayaLayout {
 }
 
 public extension BayaLayoutable {
-    func layoutMatchParent(
+    func layoutMatchingParent(
         width: Bool,
         height: Bool,
         layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)

--- a/Baya/layouts/BayaOriginResetLayout.swift
+++ b/Baya/layouts/BayaOriginResetLayout.swift
@@ -37,7 +37,7 @@ public struct BayaOriginResetLayout: BayaLayout {
 }
 
 public extension BayaLayoutable {
-    func layoutResetOrigin(layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaLayout {
+    func layoutResettingOrigin(layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaLayout {
         return BayaOriginResetLayout(element: self, layoutMargins: layoutMargins)
     }
 }

--- a/Baya/layouts/BayaPercentalSizeLayout.swift
+++ b/Baya/layouts/BayaPercentalSizeLayout.swift
@@ -7,15 +7,15 @@ import Foundation
 import UIKit
 
 /**
-    A Layout that uses a percental portion of the given size for measurement.
+    A Layout that uses a portion of the given size for measurement.
  */
-public struct BayaPercentalSizeLayout: BayaLayout {
+public struct BayaProportionalSizeLayout: BayaLayout {
     public var layoutMargins: UIEdgeInsets
     public var frame: CGRect
 
     private var element: BayaLayoutable
-    private var percentalWidth: CGFloat?
-    private var percentalHeight: CGFloat?
+    private var widthFactor: CGFloat?
+    private var heightFactor: CGFloat?
 
     /**
         - Parameter element: The element to be laid out
@@ -27,12 +27,12 @@ public struct BayaPercentalSizeLayout: BayaLayout {
      */
     init(
         element: BayaLayoutable,
-        width: CGFloat? = nil,
-        height: CGFloat? = nil,
+        widthFactor: CGFloat? = nil,
+        heightFactor: CGFloat? = nil,
         layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) {
         self.element = element
-        self.percentalWidth = width
-        self.percentalHeight = height
+        self.widthFactor = widthFactor
+        self.heightFactor = heightFactor
         self.layoutMargins = layoutMargins
         self.frame = CGRect()
     }
@@ -44,26 +44,26 @@ public struct BayaPercentalSizeLayout: BayaLayout {
 
     public mutating func sizeThatFits(_ size: CGSize) -> CGSize {
         let fit = element.sizeThatFitsWithMargins(CGSize(
-                width: size.width * (percentalWidth ?? 1),
-                height: size.height * (percentalHeight ?? 1)))
+                width: size.width * (widthFactor ?? 1),
+                height: size.height * (heightFactor ?? 1)))
             .addMargins(ofElement: element)
 
         return CGSize(
-            width: (percentalWidth != nil) ? max(size.width * percentalWidth!, fit.width) : fit.width,
-            height: (percentalHeight != nil) ? max(size.height * percentalHeight!, fit.height) : fit.height)
+            width: (widthFactor != nil) ? max(size.width * widthFactor!, fit.width) : fit.width,
+            height: (heightFactor != nil) ? max(size.height * heightFactor!, fit.height) : fit.height)
     }
 }
 
 public extension BayaLayoutable {
-    func layoutPercentalSize(
-        width: CGFloat? = nil,
-        height: CGFloat? = nil,
+    func layoutWithPortion(
+        ofWidth: CGFloat? = nil,
+        ofHeight: CGFloat? = nil,
         layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)
-            -> BayaPercentalSizeLayout {
-        return BayaPercentalSizeLayout(
+            -> BayaProportionalSizeLayout {
+        return BayaProportionalSizeLayout(
             element: self,
-            width: width,
-            height: height,
+            widthFactor: ofWidth,
+            heightFactor: ofHeight,
             layoutMargins: layoutMargins)
     }
 }

--- a/Baya/layouts/BayaSquareLayout.swift
+++ b/Baya/layouts/BayaSquareLayout.swift
@@ -69,7 +69,7 @@ private extension CGSize {
 // MARK: Square shortcuts.
 
 public extension BayaLayoutable {
-    func layoutSquare(
+    func layoutAsSquare(
         referenceSide: BayaLayoutOptions.Orientation,
         layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)
             -> BayaSquareLayout {

--- a/BayaTests/BayaEqualSegmentsTests.swift
+++ b/BayaTests/BayaEqualSegmentsTests.swift
@@ -42,7 +42,7 @@ class BayaEqualSegmentsTests: XCTestCase {
 
     func testEmptyArray() {
         var layout = [BayaLayoutable]()
-            .layoutEqualSegments(
+            .layoutAsEqualSegments(
                 orientation: .horizontal,
                 gutter: spacing)
         layout.startLayout(
@@ -52,7 +52,7 @@ class BayaEqualSegmentsTests: XCTestCase {
 
     func testHorizontal() {
         var layout = [l1, l2, l3]
-            .layoutEqualSegments(
+            .layoutAsEqualSegments(
                 orientation: .horizontal,
                 gutter: spacing)
 
@@ -84,7 +84,7 @@ class BayaEqualSegmentsTests: XCTestCase {
     
     func testHorizontalSmallEnforcedFrame() {
         var layout = [l1, l2, l3]
-            .layoutEqualSegments(
+            .layoutAsEqualSegments(
                 orientation: .horizontal,
                 gutter: spacing)
         
@@ -116,7 +116,7 @@ class BayaEqualSegmentsTests: XCTestCase {
 
     func testVertical() {
         var layout = [l1, l2, l3]
-            .layoutEqualSegments(
+            .layoutAsEqualSegments(
                 orientation: .vertical,
                 gutter: spacing)
         
@@ -147,7 +147,7 @@ class BayaEqualSegmentsTests: XCTestCase {
     }
 
     func testMeasureHorizontal() {
-        var layout = [l1, l2, l3].layoutEqualSegments(
+        var layout = [l1, l2, l3].layoutAsEqualSegments(
             orientation: .horizontal,
             gutter: spacing)
 
@@ -165,7 +165,7 @@ class BayaEqualSegmentsTests: XCTestCase {
     }
 
     func testMeasureVertical() {
-        var layout = [l1, l2, l3].layoutEqualSegments(
+        var layout = [l1, l2, l3].layoutAsEqualSegments(
             orientation: .vertical,
             gutter: spacing)
 
@@ -184,7 +184,7 @@ class BayaEqualSegmentsTests: XCTestCase {
 
     func testDifferentTypesPossible() {
         let anotherOne = AnotherOne()
-        var layout = [l1, anotherOne].layoutEqualSegments(orientation: .horizontal)
+        var layout = [l1, anotherOne].layoutAsEqualSegments(orientation: .horizontal)
         layout.startLayout(with: layoutRect)
         XCTAssert(true)
     }

--- a/BayaTests/BayaFixedSizeTests.swift
+++ b/BayaTests/BayaFixedSizeTests.swift
@@ -29,7 +29,7 @@ class BayaFixedSizeTests: XCTestCase {
 
     func testFixedHeight() {
         let fixedHeight: CGFloat = 100
-        var layout = l.layoutFixedSize(width: nil, height: fixedHeight)
+        var layout = l.layoutWithFixedSize(width: nil, height: fixedHeight)
         layout.startLayout(with: layoutRect)
 
         XCTAssertEqual(
@@ -44,7 +44,7 @@ class BayaFixedSizeTests: XCTestCase {
 
     func testFixedWidth() {
         let fixedWidth: CGFloat = 75
-        var layout = l.layoutFixedSize(width: fixedWidth, height: nil)
+        var layout = l.layoutWithFixedSize(width: fixedWidth, height: nil)
         layout.startLayout(with: layoutRect)
 
         XCTAssertEqual(
@@ -59,7 +59,7 @@ class BayaFixedSizeTests: XCTestCase {
 
     func testFixedSize() {
         let fixedSize: CGSize = CGSize(width: 55, height: 99)
-        var layout = l.layoutFixedSize(width: fixedSize.width, height: fixedSize.height)
+        var layout = l.layoutWithFixedSize(width: fixedSize.width, height: fixedSize.height)
         layout.startLayout(with: layoutRect)
 
         XCTAssertEqual(
@@ -74,7 +74,7 @@ class BayaFixedSizeTests: XCTestCase {
 
     func testMeasureFixedSize() {
         let fixedSize: CGSize = CGSize(width: 40, height: 70)
-        var layout = l.layoutFixedSize(width: fixedSize.width, height: fixedSize.height)
+        var layout = l.layoutWithFixedSize(width: fixedSize.width, height: fixedSize.height)
         let fit = layout.sizeThatFits(layoutRect.size)
 
         XCTAssertEqual(
@@ -85,7 +85,7 @@ class BayaFixedSizeTests: XCTestCase {
     
     func testMeasureFixedHeight() {
         let fixedHeight: CGFloat = 60
-        var layout = l.layoutFixedSize(width: nil, height: fixedHeight)
+        var layout = l.layoutWithFixedSize(width: nil, height: fixedHeight)
         let fit = layout.sizeThatFits(layoutRect.size)
 
         XCTAssertEqual(
@@ -98,7 +98,7 @@ class BayaFixedSizeTests: XCTestCase {
 
     func testMeasureFixedWidth() {
         let fixedWidth: CGFloat = 34
-        var layout = l.layoutFixedSize(width: fixedWidth, height: nil)
+        var layout = l.layoutWithFixedSize(width: fixedWidth, height: nil)
         let fit = layout.sizeThatFits(layoutRect.size)
 
         XCTAssertEqual(

--- a/BayaTests/BayaFlexibleContentTests.swift
+++ b/BayaTests/BayaFlexibleContentTests.swift
@@ -41,10 +41,10 @@ class BayaFlexibleContentTests: XCTestCase {
     }
 
     func testMeasureHorizontal() {
-        var layout = l2.layoutFlexibleContent(
+        var layout = l2.layoutFlexible(
+            elementBefore: l1,
+            elementAfter: l3,
             orientation: .horizontal,
-            before: l1,
-            after: l3,
             spacing: Int(spacing),
             layoutMargins: UIEdgeInsets.zero)
         let measuredSize = layout.sizeThatFitsWithMargins(layoutRect.size)
@@ -60,10 +60,10 @@ class BayaFlexibleContentTests: XCTestCase {
     }
 
     func testMeasureVertical() {
-        var layout = l2.layoutFlexibleContent(
+        var layout = l2.layoutFlexible(
+            elementBefore: l1,
+            elementAfter: l3,
             orientation: .vertical,
-            before: l1,
-            after: l3,
             spacing: Int(spacing),
             layoutMargins: UIEdgeInsets.zero)
         let measuredSize = layout.sizeThatFitsWithMargins(layoutRect.size)
@@ -79,10 +79,10 @@ class BayaFlexibleContentTests: XCTestCase {
     }
 
     func testHorizontal() {
-        var layout = l2.layoutFlexibleContent(
+        var layout = l2.layoutFlexible(
+            elementBefore: l1,
+            elementAfter: l3,
             orientation: .horizontal,
-            before: l1,
-            after: l3,
             spacing: Int(spacing),
             layoutMargins: UIEdgeInsets.zero)
         layout.startLayout(with: layoutRect)
@@ -111,10 +111,10 @@ class BayaFlexibleContentTests: XCTestCase {
     }
 
     func testVertical() {
-        var layout = l2.layoutFlexibleContent(
+        var layout = l2.layoutFlexible(
+            elementBefore: l1,
+            elementAfter: l3,
             orientation: .vertical,
-            before: l1,
-            after: l3,
             spacing: Int(spacing),
             layoutMargins: UIEdgeInsets.zero)
         layout.startLayout(with: layoutRect)
@@ -143,10 +143,10 @@ class BayaFlexibleContentTests: XCTestCase {
     }
 
     func testHorizontalWithNoOptionalElements() {
-        var layout = l2.layoutFlexibleContent(
+        var layout = l2.layoutFlexible(
+            elementBefore: nil,
+            elementAfter: nil,
             orientation: .horizontal,
-            before: nil,
-            after: nil,
             spacing: Int(spacing),
             layoutMargins: UIEdgeInsets.zero)
         layout.startLayout(with: layoutRect)
@@ -159,10 +159,10 @@ class BayaFlexibleContentTests: XCTestCase {
     }
 
     func testVerticalWithNoOptionalElements() {
-        var layout = l2.layoutFlexibleContent(
+        var layout = l2.layoutFlexible(
+            elementBefore: nil,
+            elementAfter: nil,
             orientation: .vertical,
-            before: nil,
-            after: nil,
             spacing: Int(spacing),
             layoutMargins: UIEdgeInsets.zero)
         layout.startLayout(with: layoutRect)
@@ -178,10 +178,10 @@ class BayaFlexibleContentTests: XCTestCase {
         l2 = TakesWhatItGets()
         l2.m(1, 2, 3, 4)
 
-        var layout = l2.layoutFlexibleContent(
+        var layout = l2.layoutFlexible(
+            elementBefore: l1,
+            elementAfter: l3,
             orientation: .horizontal,
-            before: l1,
-            after: l3,
             spacing: Int(spacing),
             layoutMargins: UIEdgeInsets.zero)
         layout.startLayout(with: layoutRect)
@@ -207,10 +207,10 @@ class BayaFlexibleContentTests: XCTestCase {
         l2 = TakesWhatItGets()
         l2.m(1, 2, 3, 4)
 
-        var layout = l2.layoutFlexibleContent(
+        var layout = l2.layoutFlexible(
+            elementBefore: l1,
+            elementAfter: l3,
             orientation: .vertical,
-            before: l1,
-            after: l3,
             spacing: Int(spacing),
             layoutMargins: UIEdgeInsets.zero)
         layout.startLayout(with: layoutRect)

--- a/BayaTests/BayaFrameTests.swift
+++ b/BayaTests/BayaFrameTests.swift
@@ -40,7 +40,7 @@ class BayaFrameTests: XCTestCase {
     }
 
     func testEmptyArray() {
-        var layout = [TestLayoutable]().layoutFrame()
+        var layout = [TestLayoutable]().layoutAsFrame()
         layout.startLayout(
             with: CGRect())
         XCTAssert(true) // Does not crash.
@@ -48,7 +48,7 @@ class BayaFrameTests: XCTestCase {
 
     func testSizes() {
         var layout = [l1, l2, l3]
-            .layoutFrame()
+            .layoutAsFrame()
         let layoutRect = CGRect(
             x: 5,
             y: 10,
@@ -78,7 +78,7 @@ class BayaFrameTests: XCTestCase {
 
     func testMeasures() {
         var layout = [l1, l2, l3]
-            .layoutFrame()
+            .layoutAsFrame()
         let size = layout.sizeThatFits(CGSize(
             width: 300,
             height: 200))

--- a/BayaTests/BayaGravityTests.swift
+++ b/BayaTests/BayaGravityTests.swift
@@ -24,7 +24,7 @@ class BayaGravityTests: XCTestCase {
     }
     
     func testMeasureLeftTop() {
-        var layout = l.layoutGravity(horizontally: .left, vertically: .top)
+        var layout = l.layoutGravitating(horizontally: .left, vertically: .top)
         let size = layout.sizeThatFits(layoutRect.size)
         XCTAssertEqual(
             size,
@@ -35,7 +35,7 @@ class BayaGravityTests: XCTestCase {
     }
     
     func testMeasureCenterTop() {
-        var layout = l.layoutGravity(horizontally: .center, vertically: .top)
+        var layout = l.layoutGravitating(horizontally: .center, vertically: .top)
         let size = layout.sizeThatFits(layoutRect.size)
         XCTAssertEqual(
             size,
@@ -46,7 +46,7 @@ class BayaGravityTests: XCTestCase {
     }
     
     func testMeasureRightTop() {
-        var layout = l.layoutGravity(horizontally: .right, vertically: .top)
+        var layout = l.layoutGravitating(horizontally: .right, vertically: .top)
         let size = layout.sizeThatFits(layoutRect.size)
         XCTAssertEqual(
             size,
@@ -57,7 +57,7 @@ class BayaGravityTests: XCTestCase {
     }
     
     func testMeasureLeftMiddle() {
-        var layout = l.layoutGravity(horizontally: .left, vertically: .middle)
+        var layout = l.layoutGravitating(horizontally: .left, vertically: .middle)
         let size = layout.sizeThatFits(layoutRect.size)
         XCTAssertEqual(
             size,
@@ -68,7 +68,7 @@ class BayaGravityTests: XCTestCase {
     }
     
     func testMeasureCenterMiddle() {
-        var layout = l.layoutGravity(horizontally: .center, vertically: .middle)
+        var layout = l.layoutGravitating(horizontally: .center, vertically: .middle)
         let size = layout.sizeThatFits(layoutRect.size)
         XCTAssertEqual(
             size,
@@ -79,7 +79,7 @@ class BayaGravityTests: XCTestCase {
     }
     
     func testMeasureRightMiddle() {
-        var layout = l.layoutGravity(horizontally: .right, vertically: .middle)
+        var layout = l.layoutGravitating(horizontally: .right, vertically: .middle)
         let size = layout.sizeThatFits(layoutRect.size)
         XCTAssertEqual(
             size,
@@ -90,7 +90,7 @@ class BayaGravityTests: XCTestCase {
     }
     
     func testMeasureLeftBottom() {
-        var layout = l.layoutGravity(horizontally: .left, vertically: .bottom)
+        var layout = l.layoutGravitating(horizontally: .left, vertically: .bottom)
         let size = layout.sizeThatFits(layoutRect.size)
         XCTAssertEqual(
             size,
@@ -101,7 +101,7 @@ class BayaGravityTests: XCTestCase {
     }
     
     func testMeasureCenterBottom() {
-        var layout = l.layoutGravity(horizontally: .center, vertically: .bottom)
+        var layout = l.layoutGravitating(horizontally: .center, vertically: .bottom)
         let size = layout.sizeThatFits(layoutRect.size)
         XCTAssertEqual(
             size,
@@ -112,7 +112,7 @@ class BayaGravityTests: XCTestCase {
     }
     
     func testMeasureRightBottom() {
-        var layout = l.layoutGravity(horizontally: .right, vertically: .bottom)
+        var layout = l.layoutGravitating(horizontally: .right, vertically: .bottom)
         let size = layout.sizeThatFits(layoutRect.size)
         XCTAssertEqual(
             size,
@@ -124,7 +124,7 @@ class BayaGravityTests: XCTestCase {
     
     func testLeftTop() {
         var layout = l
-            .layoutGravity(horizontally: .left, vertically: .top)
+            .layoutGravitating(horizontally: .left, vertically: .top)
         layout.startLayout(with: layoutRect)
         XCTAssertEqual(
             l.frame,
@@ -138,7 +138,7 @@ class BayaGravityTests: XCTestCase {
     
     func testCenterTop() {
         var layout = l
-            .layoutGravity(horizontally: .center, vertically: .top)
+            .layoutGravitating(horizontally: .center, vertically: .top)
         layout.layoutWith(frame: layoutRect)
         XCTAssertEqual(
             l.frame,
@@ -152,7 +152,7 @@ class BayaGravityTests: XCTestCase {
     
     func testRightTop() {
         var layout = l
-            .layoutGravity(horizontally: .right, vertically: .top)
+            .layoutGravitating(horizontally: .right, vertically: .top)
         layout.layoutWith(frame: layoutRect)
         XCTAssertEqual(
             l.frame,
@@ -167,7 +167,7 @@ class BayaGravityTests: XCTestCase {
     
     func testLeftMiddle() {
         var layout = l
-            .layoutGravity(horizontally: .left, vertically: .middle)
+            .layoutGravitating(horizontally: .left, vertically: .middle)
         layout.layoutWith(frame: layoutRect)
         XCTAssertEqual(
             l.frame,
@@ -181,7 +181,7 @@ class BayaGravityTests: XCTestCase {
     
     func testCenterMiddle() {
         var layout = l
-            .layoutGravity(horizontally: .center, vertically: .middle)
+            .layoutGravitating(horizontally: .center, vertically: .middle)
         layout.layoutWith(frame: layoutRect)
         XCTAssertEqual(
             l.frame,
@@ -195,7 +195,7 @@ class BayaGravityTests: XCTestCase {
     
     func testRightMiddle() {
         var layout = l
-            .layoutGravity(horizontally: .right, vertically: .middle)
+            .layoutGravitating(horizontally: .right, vertically: .middle)
         layout.layoutWith(frame: layoutRect)
         XCTAssertEqual(
             l.frame,
@@ -209,7 +209,7 @@ class BayaGravityTests: XCTestCase {
     
     func testLeftBottom() {
         var layout = l
-            .layoutGravity(horizontally: .left, vertically: .bottom)
+            .layoutGravitating(horizontally: .left, vertically: .bottom)
         layout.layoutWith(frame: layoutRect)
         XCTAssertEqual(
             l.frame,
@@ -223,7 +223,7 @@ class BayaGravityTests: XCTestCase {
     
     func testCenterBottom() {
         var layout = l
-            .layoutGravity(horizontally: .center, vertically: .bottom)
+            .layoutGravitating(horizontally: .center, vertically: .bottom)
         layout.layoutWith(frame: layoutRect)
         XCTAssertEqual(
             l.frame,
@@ -237,7 +237,7 @@ class BayaGravityTests: XCTestCase {
     
     func testRightBottom() {
         var layout = l
-            .layoutGravity(horizontally: .right, vertically: .bottom)
+            .layoutGravitating(horizontally: .right, vertically: .bottom)
         layout.layoutWith(frame: layoutRect)
         XCTAssertEqual(
             l.frame,

--- a/BayaTests/BayaLinearTests.swift
+++ b/BayaTests/BayaLinearTests.swift
@@ -39,13 +39,13 @@ class BayaLinearTests: XCTestCase {
 
     func testEmptyArray() {
         var layout = [TestLayoutable]()
-            .layoutLinear(orientation: .horizontal)
+            .layoutLinearly(orientation: .horizontal)
         layout.startLayout(with: CGRect())
         XCTAssert(true) // Does not crash.
     }
 
     func testHorizontal() {
-        var layout = [l1, l2, l3].layoutLinear(
+        var layout = [l1, l2, l3].layoutLinearly(
             orientation: .horizontal,
             direction: .normal,
             spacing: Int(spacing))
@@ -71,7 +71,7 @@ class BayaLinearTests: XCTestCase {
     }
 
     func testHorizontalReversed() {
-        var layout = [l1, l2, l3].layoutLinear(
+        var layout = [l1, l2, l3].layoutLinearly(
             orientation: .horizontal,
             direction: .reversed,
             spacing: Int(spacing))
@@ -107,7 +107,7 @@ class BayaLinearTests: XCTestCase {
     }
 
     func testVertical() {
-        var layout = [l1, l2, l3].layoutLinear(
+        var layout = [l1, l2, l3].layoutLinearly(
             orientation: .vertical,
             direction: .normal,
             spacing: Int(spacing))
@@ -127,7 +127,7 @@ class BayaLinearTests: XCTestCase {
     }
 
     func testVerticalReversed() {
-        var layout = [l1, l2, l3].layoutLinear(
+        var layout = [l1, l2, l3].layoutLinearly(
             orientation: .vertical,
             direction: .reversed,
             spacing: 20)
@@ -162,7 +162,7 @@ class BayaLinearTests: XCTestCase {
     }
 
     func testMeasureHorizontal() {
-        var layout = [l1, l2, l3].layoutLinear(
+        var layout = [l1, l2, l3].layoutLinearly(
             orientation: .horizontal,
             direction: .normal,
             spacing: Int(spacing))
@@ -178,7 +178,7 @@ class BayaLinearTests: XCTestCase {
     }
 
     func testMeasureVertical() {
-        var layout = [l1, l2, l3].layoutLinear(
+        var layout = [l1, l2, l3].layoutLinearly(
             orientation: .vertical,
             direction: .normal,
             spacing: Int(spacing))
@@ -195,7 +195,7 @@ class BayaLinearTests: XCTestCase {
     
     func testDifferentTypesPossible() {
         let anotherOne = AnotherOne()
-        var layout = [l1, anotherOne].layoutLinear(orientation: .horizontal)
+        var layout = [l1, anotherOne].layoutLinearly(orientation: .horizontal)
         layout.startLayout(with: layoutRect)
         XCTAssert(true)
     }

--- a/BayaTests/BayaMatchParentTests.swift
+++ b/BayaTests/BayaMatchParentTests.swift
@@ -24,7 +24,7 @@ class BayaMatchParentTests: XCTestCase {
     }
 
     func testMatchParent() {
-        var layout = l.layoutMatchParent(width: true, height: true)
+        var layout = l.layoutMatchingParent(width: true, height: true)
         layout.startLayout(with: layoutRect)
 
         XCTAssertEqual(
@@ -38,7 +38,7 @@ class BayaMatchParentTests: XCTestCase {
     }
 
     func testMatchParentWidth() {
-        var layout = l.layoutMatchParent(width: true, height: false)
+        var layout = l.layoutMatchingParent(width: true, height: false)
         layout.startLayout(with: layoutRect)
 
         XCTAssertEqual(
@@ -52,7 +52,7 @@ class BayaMatchParentTests: XCTestCase {
     }
 
     func testMatchParentHeight() {
-        var layout = l.layoutMatchParent(width: false, height: true)
+        var layout = l.layoutMatchingParent(width: false, height: true)
         layout.startLayout(with: layoutRect)
         
         XCTAssertEqual(
@@ -66,7 +66,7 @@ class BayaMatchParentTests: XCTestCase {
     }
 
     func testMeasureMatchParent() {
-        var layout = l.layoutMatchParent(width: true, height: true)
+        var layout = l.layoutMatchingParent(width: true, height: true)
         let fit = layout.sizeThatFits(layoutRect.size)
         
         XCTAssertEqual(
@@ -76,7 +76,7 @@ class BayaMatchParentTests: XCTestCase {
     }
 
     func testMeasureMatchParentWidth() {
-        var layout = l.layoutMatchParent(width: true, height: false)
+        var layout = l.layoutMatchingParent(width: true, height: false)
         let fit = layout.sizeThatFits(layoutRect.size)
         
         XCTAssertEqual(
@@ -88,7 +88,7 @@ class BayaMatchParentTests: XCTestCase {
     }
 
     func testMeasureMatchParentHeight() {
-        var layout = l.layoutMatchParent(width: false, height: true)
+        var layout = l.layoutMatchingParent(width: false, height: true)
         let fit = layout.sizeThatFits(layoutRect.size)
         
         XCTAssertEqual(

--- a/BayaTests/BayaOriginResetTests.swift
+++ b/BayaTests/BayaOriginResetTests.swift
@@ -23,7 +23,7 @@ class BayaOriginResetTests: XCTestCase {
     }
 
     func testMeasure() {
-        var layout = l.layoutResetOrigin()
+        var layout = l.layoutResettingOrigin()
         let size = layout.sizeThatFits(layoutRect.size)
         XCTAssertEqual(
             size,
@@ -34,7 +34,7 @@ class BayaOriginResetTests: XCTestCase {
     }
 
     func testResetsOrigin() {
-        var layout = l.layoutResetOrigin()
+        var layout = l.layoutResettingOrigin()
         l.frame.origin.x = 20;
         l.frame.origin.y = 31;
         layout.layoutWith(frame: layoutRect)


### PR DESCRIPTION
Renamed the methods to be better readable when writing layout code.

Concept example from slack:
```
[
  scrollView.layoutMatchingParent(),
  [page1Layout, page2Layout, page3Layout]
    .layoutAsEqualSegments(orientation: .vertical, gutter: 8)
    .layoutMatchingParent()
    .layoutByMultiplyingParentFrame(times: 3, gutter: 8)
    .layoutAsContent(of: scrollView)
].layoutAsFrame()
```

I did not rename scroll view related layouts because I intent to remove and replace them with simpler variants in the next PR.