### PR TITLE
Feature separate margin system

### DIFF
--- a/Baya/BayaLayout.swift
+++ b/Baya/BayaLayout.swift
@@ -22,8 +22,8 @@ public extension BayaLayout {
     */
     mutating public func startLayout(with frame: CGRect) {
         let origin = CGPoint(
-            x: frame.origin.x + self.layoutMargins.left,
-            y: frame.origin.y + self.layoutMargins.top)
+            x: frame.origin.x + self.bayaMargins.left,
+            y: frame.origin.y + self.bayaMargins.top)
         let combinedSize = Self.combineSizeForLayout(
             for: self,
             wrappingSize: self.sizeThatFitsWithMargins(frame.size),
@@ -44,14 +44,14 @@ public extension BayaLayout {
         sizeThatFits method, use this convenience helper.
     */
     mutating public func startMeasure(with size: CGSize) -> CGSize {
-        guard self.layoutModes.width == .wrapContent || self.layoutModes.height == .wrapContent else {
+        guard self.bayaModes.width == .wrapContent || self.bayaModes.height == .wrapContent else {
             return size
         }
         let measuredSize = self.sizeThatFitsWithMargins(size)
         let adjustedSize = measuredSize.addMargins(ofElement: self)
         return CGSize(
-            width: self.layoutModes.width == .wrapContent ? adjustedSize.width : size.width,
-            height: self.layoutModes.height == .wrapContent ? adjustedSize.height : size.height)
+            width: self.bayaModes.width == .wrapContent ? adjustedSize.width : size.width,
+            height: self.bayaModes.height == .wrapContent ? adjustedSize.height : size.height)
     }
 }
 
@@ -89,7 +89,7 @@ internal extension BayaLayout {
         wrappingSize: CGSize,
         matchingSize: CGSize) -> CGSize {
         return CGSize(
-            width: element.layoutModes.width == .matchParent ? matchingSize.width : wrappingSize.width,
-            height: element.layoutModes.height  == .matchParent ? matchingSize.height : wrappingSize.height)
+            width: element.bayaModes.width == .matchParent ? matchingSize.width : wrappingSize.width,
+            height: element.bayaModes.height  == .matchParent ? matchingSize.height : wrappingSize.height)
     }
 }

--- a/Baya/BayaLayoutable.swift
+++ b/Baya/BayaLayoutable.swift
@@ -94,6 +94,10 @@ internal extension Sequence where Iterator.Element: BayaLayoutable {
     Apply LayoutTarget to UIView.
 */
 extension UIView: BayaLayoutable {
+    public var bayaMargins: UIEdgeInsets {
+        return UIEdgeInsets.zero
+    }
+    
     public func layoutWith(frame: CGRect) {
         setFrameSafely(frame)
     }

--- a/Baya/BayaLayoutable.swift
+++ b/Baya/BayaLayoutable.swift
@@ -11,9 +11,9 @@ import UIKit
     Can be a UIView or another Layout.
 */
 public protocol BayaLayoutable {
-    var layoutMargins: UIEdgeInsets {get}
+    var bayaMargins: UIEdgeInsets {get}
     var frame: CGRect {get}
-    var layoutModes: BayaLayoutOptions.Modes {get}
+    var bayaModes: BayaLayoutOptions.Modes {get}
     mutating func sizeThatFits(_ size: CGSize) -> CGSize
     mutating func layoutWith(frame: CGRect)
 }
@@ -22,7 +22,7 @@ public protocol BayaLayoutable {
     Public helper.
 */
 public extension BayaLayoutable {
-    var layoutModes: BayaLayoutOptions.Modes {
+    var bayaModes: BayaLayoutOptions.Modes {
         return BayaLayoutOptions.Modes.default
     }
 }
@@ -32,11 +32,11 @@ public extension BayaLayoutable {
 */
 internal extension BayaLayoutable {
     var verticalMargins: CGFloat {
-        return layoutMargins.top + layoutMargins.bottom
+        return bayaMargins.top + bayaMargins.bottom
     }
 
     var horizontalMargins: CGFloat {
-        return layoutMargins.left + layoutMargins.right
+        return bayaMargins.left + bayaMargins.right
     }
 
     var heightWithMargins: CGFloat {
@@ -140,8 +140,8 @@ internal extension CGRect {
     func subtractMargins(ofElement element: BayaLayoutable) -> CGRect {
         return CGRect(
             origin: CGPoint(
-                x: minX + element.layoutMargins.left,
-                y: minY + element.layoutMargins.top),
+                x: minX + element.bayaMargins.left,
+                y: minY + element.bayaMargins.top),
             size: size.subtractMargins(ofElement: element))
     }
 }

--- a/Baya/layouts/BayaEqualSegmentsLayout.swift
+++ b/Baya/layouts/BayaEqualSegmentsLayout.swift
@@ -10,7 +10,7 @@ import UIKit
     A layout that distributes the available size evenly among the given elements.
 */
 public struct BayaEqualSegmentsLayout: BayaLayout, BayaLayoutIterator {
-    public var layoutMargins: UIEdgeInsets
+    public var bayaMargins: UIEdgeInsets
     public var frame: CGRect
     var orientation: BayaLayoutOptions.Orientation
     var spacing: CGFloat
@@ -23,11 +23,11 @@ public struct BayaEqualSegmentsLayout: BayaLayout, BayaLayoutIterator {
         elements: [BayaLayoutable],
         orientation: BayaLayoutOptions.Orientation,
         spacing: CGFloat = 0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
         self.elements = elements
         self.orientation = orientation
         self.spacing = spacing
-        self.layoutMargins = layoutMargins
+        self.bayaMargins = bayaMargins
         self.frame = CGRect()
     }
 
@@ -54,15 +54,15 @@ public struct BayaEqualSegmentsLayout: BayaLayout, BayaLayoutIterator {
                 if let e1 = e1 {
                     origin = CGPoint(
                         x: e1.frame.minX
-                            - e1.layoutMargins.left
+                            - e1.bayaMargins.left
                             + segmentWidth
                             + spacing
-                            + e2.layoutMargins.left,
-                        y: frame.minY + e2.layoutMargins.top)
+                            + e2.bayaMargins.left,
+                        y: frame.minY + e2.bayaMargins.top)
                 } else {
                     origin = CGPoint(
-                        x: frame.minX + e2.layoutMargins.left,
-                        y: frame.minY + e2.layoutMargins.top)
+                        x: frame.minX + e2.bayaMargins.left,
+                        y: frame.minY + e2.bayaMargins.top)
                 }
                 return CGRect(origin: origin, size: size)
             }
@@ -79,16 +79,16 @@ public struct BayaEqualSegmentsLayout: BayaLayout, BayaLayoutIterator {
                     matchingSize: segmentSize.subtractMargins(ofElement: e2))
                 if let e1 = e1 {
                     origin = CGPoint(
-                        x: frame.minX + e2.layoutMargins.left,
+                        x: frame.minX + e2.bayaMargins.left,
                         y: e1.frame.minY
-                            - e1.layoutMargins.top
+                            - e1.bayaMargins.top
                             + segmentHeight
                             + spacing
-                            + e2.layoutMargins.top)
+                            + e2.bayaMargins.top)
                 } else {
                     origin = CGPoint(
-                        x: frame.minX + e2.layoutMargins.left,
-                        y: frame.minY + e2.layoutMargins.top)
+                        x: frame.minX + e2.bayaMargins.left,
+                        y: frame.minY + e2.bayaMargins.top)
                 }
                 return CGRect(origin: origin, size: size)
             }
@@ -135,18 +135,18 @@ public extension Sequence where Iterator.Element: BayaLayoutable {
     /// - parameter orientation: Determines if the elements should be laid out in horizontal or vertical direction. Also
     ///   determines which side of the available size should be segmented and distributed among the elements.
     /// - parameter spacing: The gap between the elements.
-    /// - parameter layoutMargins: The layout's margins.
+    /// - parameter bayaMargins: The layout's margins.
     /// - returns: A `BayaEqualSegmentsLayout`.
     func layoutAsEqualSegments(
         orientation: BayaLayoutOptions.Orientation,
         spacing: CGFloat = 0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero)
             -> BayaEqualSegmentsLayout {
         return BayaEqualSegmentsLayout(
             elements: self.array(),
             orientation: orientation,
             spacing: spacing,
-            layoutMargins: layoutMargins)
+            bayaMargins: bayaMargins)
     }
 }
 
@@ -156,17 +156,17 @@ public extension Sequence where Iterator.Element == BayaLayoutable {
     /// - parameter orientation: Determines if the elements should be laid out in horizontal or vertical direction. Also
     ///   determines which side of the available size should be segmented and distributed among the elements.
     /// - parameter spacing: The gap between the elements.
-    /// - parameter layoutMargins: The layout's margins.
+    /// - parameter bayaMargins: The layout's margins.
     /// - returns: A `BayaEqualSegmentsLayout`.
     func layoutAsEqualSegments(
         orientation: BayaLayoutOptions.Orientation,
         spacing: CGFloat = 0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero)
             -> BayaEqualSegmentsLayout {
         return BayaEqualSegmentsLayout(
             elements: self.array(),
             orientation: orientation,
             spacing: spacing,
-            layoutMargins: layoutMargins)
+            bayaMargins: bayaMargins)
     }
 }

--- a/Baya/layouts/BayaEqualSegmentsLayout.swift
+++ b/Baya/layouts/BayaEqualSegmentsLayout.swift
@@ -22,8 +22,8 @@ public struct BayaEqualSegmentsLayout: BayaLayout, BayaLayoutIterator {
     init(
         elements: [BayaLayoutable],
         orientation: BayaLayoutOptions.Orientation,
-        spacing: CGFloat = 0,
-        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        spacing: CGFloat,
+        bayaMargins: UIEdgeInsets) {
         self.elements = elements
         self.orientation = orientation
         self.spacing = spacing

--- a/Baya/layouts/BayaFixedSizeLayout.swift
+++ b/Baya/layouts/BayaFixedSizeLayout.swift
@@ -8,12 +8,12 @@ import UIKit
 
 /**
     Sets a fixed size for the element.
-    The `layoutModes` will be `.wrapContent` on sides with fixed size, or the element's `layoutModes`.
+    The `bayaModes` will be `.wrapContent` on sides with fixed size, or the element's `bayaModes`.
 */
 public struct BayaFixedSizeLayout: BayaLayout {
-    public var layoutMargins = UIEdgeInsets.zero
+    public var bayaMargins = UIEdgeInsets.zero
     public var frame: CGRect
-    public var layoutModes: BayaLayoutOptions.Modes
+    public var bayaModes: BayaLayoutOptions.Modes
     private var element: BayaLayoutable
     private var measure: CGSize?
     private var fixedWidth: CGFloat?
@@ -27,9 +27,9 @@ public struct BayaFixedSizeLayout: BayaLayout {
         self.fixedHeight = height
         self.element = element
         self.frame = CGRect()
-        self.layoutModes = BayaLayoutOptions.Modes(
-            width: width != nil ? .wrapContent : element.layoutModes.width,
-            height: height != nil ? .wrapContent : element.layoutModes.height)
+        self.bayaModes = BayaLayoutOptions.Modes(
+            width: width != nil ? .wrapContent : element.bayaModes.width,
+            height: height != nil ? .wrapContent : element.bayaModes.height)
     }
 
     mutating public func layoutWith(frame: CGRect) {
@@ -46,11 +46,11 @@ public struct BayaFixedSizeLayout: BayaLayout {
                 height: fixedHeight?.subtract(element.verticalMargins) ?? defaultSize.height)
         }
 
-        let layoutMargins = element.layoutMargins
+        let bayaMargins = element.bayaMargins
         element.layoutWith(frame: CGRect(
             origin: CGPoint(
-                x: frame.origin.x + layoutMargins.left,
-                y: frame.origin.y + layoutMargins.top),
+                x: frame.origin.x + bayaMargins.left,
+                y: frame.origin.y + bayaMargins.top),
             size: size))
     }
 
@@ -65,9 +65,9 @@ public struct BayaFixedSizeLayout: BayaLayout {
 public extension BayaLayoutable {
     /// Sets a fixed size for the element.
     /// - parameter width: The desired width in points. If `nil` is passed as parameter the width is determined in
-    ///   accordance with the element's `layoutModes`.
+    ///   accordance with the element's `bayaModes`.
     /// - parameter height: The desired height in points. If `nil` is passed as parameter the height is determined
-    ///   in accordance with the element's `layoutModes`.
+    ///   in accordance with the element's `bayaModes`.
     /// - returns: A `BayaFixedSizeLayout`.
     func layoutWithFixedSize(
         width: CGFloat?,

--- a/Baya/layouts/BayaFlexibleContentLayout.swift
+++ b/Baya/layouts/BayaFlexibleContentLayout.swift
@@ -12,7 +12,7 @@ import UIKit
     element will be measured and positioned with the remaining space.
  */
 public struct BayaFlexibleContentLayout: BayaLayout {
-    public var layoutMargins: UIEdgeInsets
+    public var bayaMargins: UIEdgeInsets
     public var frame: CGRect
     var orientation: BayaLayoutOptions.Orientation
     var spacing: CGFloat
@@ -24,10 +24,10 @@ public struct BayaFlexibleContentLayout: BayaLayout {
         elements: (before: BayaLayoutable?, content: BayaLayoutable, after: BayaLayoutable?),
         orientation: BayaLayoutOptions.Orientation,
         spacing: CGFloat = 0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
         self.elements = elements
         self.orientation = orientation
-        self.layoutMargins = layoutMargins
+        self.bayaMargins = bayaMargins
         self.spacing = spacing
         self.frame = CGRect()
     }
@@ -76,19 +76,19 @@ public struct BayaFlexibleContentLayout: BayaLayout {
         case .horizontal:
             if let elementBefore = elements.before {
                 elements.before?.layoutWith(frame: CGRect(
-                    x: frame.minX + elementBefore.layoutMargins.left,
-                    y: frame.minY + elementBefore.layoutMargins.top,
+                    x: frame.minX + elementBefore.bayaMargins.left,
+                    y: frame.minY + elementBefore.bayaMargins.top,
                     width: measures.before!.width,
-                    height: elementBefore.layoutModes.height == .wrapContent ?
+                    height: elementBefore.bayaModes.height == .wrapContent ?
                         measures.before!.height : frame.height - elementBefore.verticalMargins))
             }
 
             if let elementAfter = elements.after {
                 elements.after?.layoutWith(frame: CGRect(
-                    x: frame.maxX - measures.after!.width - elementAfter.layoutMargins.right,
-                    y: frame.minY + elementAfter.layoutMargins.top,
+                    x: frame.maxX - measures.after!.width - elementAfter.bayaMargins.right,
+                    y: frame.minY + elementAfter.bayaMargins.top,
                     width: measures.after!.width,
-                    height: elementAfter.layoutModes.width == .wrapContent ?
+                    height: elementAfter.bayaModes.width == .wrapContent ?
                         measures.after!.height : frame.height - elementAfter.verticalMargins))
             }
 
@@ -96,40 +96,40 @@ public struct BayaFlexibleContentLayout: BayaLayout {
             elements.content.layoutWith(frame: CGRect(
                 x: frame.minX
                     + relevantBeforeWidth
-                    + elementContent.layoutMargins.left,
-                y: frame.minY + elementContent.layoutMargins.top,
-                width: elementContent.layoutModes.width == .wrapContent ?
+                    + elementContent.bayaMargins.left,
+                y: frame.minY + elementContent.bayaMargins.top,
+                width: elementContent.bayaModes.width == .wrapContent ?
                     measures.content!.width : frame.width - relevantBeforeWidth - relevantAfterWidth,
-                height: elementContent.layoutModes.height == .wrapContent ?
+                height: elementContent.bayaModes.height == .wrapContent ?
                     measures.content!.height : frame.height - elementContent.verticalMargins))
         case .vertical:
             if let elementBefore = elements.before {
                 elements.before?.layoutWith(frame: CGRect(
-                    x: frame.minX + elementBefore.layoutMargins.left,
-                    y: frame.minY + elementBefore.layoutMargins.top,
-                    width:  elementBefore.layoutModes.width == .wrapContent ?
+                    x: frame.minX + elementBefore.bayaMargins.left,
+                    y: frame.minY + elementBefore.bayaMargins.top,
+                    width:  elementBefore.bayaModes.width == .wrapContent ?
                         measures.before!.width : frame.width - elementBefore.horizontalMargins,
                     height: measures.before!.height))
             }
 
             if let elementAfter = elements.after {
                 elements.after?.layoutWith(frame: CGRect(
-                    x: frame.minX + elementAfter.layoutMargins.left,
-                    y: frame.maxY - measures.after!.height - elementAfter.layoutMargins.bottom,
-                    width: elementAfter.layoutModes.width == .wrapContent ?
+                    x: frame.minX + elementAfter.bayaMargins.left,
+                    y: frame.maxY - measures.after!.height - elementAfter.bayaMargins.bottom,
+                    width: elementAfter.bayaModes.width == .wrapContent ?
                         measures.after!.width : frame.width - elementAfter.horizontalMargins,
                     height: measures.after!.height))
             }
 
             let elementContent = elements.content
             elements.content.layoutWith(frame: CGRect(
-                x: frame.minX + elementContent.layoutMargins.left,
+                x: frame.minX + elementContent.bayaMargins.left,
                 y: frame.minY
                     + relevantBeforeHeight
-                    + elementContent.layoutMargins.top,
-                width: elementContent.layoutModes.width == .wrapContent ?
+                    + elementContent.bayaMargins.top,
+                width: elementContent.bayaModes.width == .wrapContent ?
                     measures.content!.width : frame.width - elementContent.horizontalMargins,
-                height: elementContent.layoutModes.height == .wrapContent ?
+                height: elementContent.bayaModes.height == .wrapContent ?
                     measures.content!.height : frame.height - relevantBeforeHeight - relevantAfterHeight))
         }
     }
@@ -173,20 +173,20 @@ public extension BayaLayoutable {
     ///   the available size.
     /// - parameter orientation: Determines if the elements should be laid out in horizontal or vertical direction.
     /// - parameter spacing: The gap between the elements.
-    /// - parameter layoutMargins: The layout's margins.
+    /// - parameter bayaMargins: The layout's margins.
     /// - returns: A `BayaFlexibleContentLayout`.
     func layoutFlexible(
         elementBefore: BayaLayoutable? = nil,
         elementAfter: BayaLayoutable? = nil,
         orientation: BayaLayoutOptions.Orientation = .horizontal,
         spacing: CGFloat = 0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero)
             -> BayaFlexibleContentLayout {
         return BayaFlexibleContentLayout(
             elements: (before:  elementBefore, content: self, after: elementAfter),
             orientation: orientation,
             spacing: spacing,
-            layoutMargins: layoutMargins)
+            bayaMargins: bayaMargins)
     }
 }
 

--- a/Baya/layouts/BayaFlexibleContentLayout.swift
+++ b/Baya/layouts/BayaFlexibleContentLayout.swift
@@ -23,8 +23,8 @@ public struct BayaFlexibleContentLayout: BayaLayout {
     init(
         elements: (before: BayaLayoutable?, content: BayaLayoutable, after: BayaLayoutable?),
         orientation: BayaLayoutOptions.Orientation,
-        spacing: CGFloat = 0,
-        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        spacing: CGFloat,
+        bayaMargins: UIEdgeInsets) {
         self.elements = elements
         self.orientation = orientation
         self.bayaMargins = bayaMargins

--- a/Baya/layouts/BayaFrameLayout.swift
+++ b/Baya/layouts/BayaFrameLayout.swift
@@ -11,16 +11,16 @@ import UIKit
     It is suggested to use it with BayaGravityLayout as children.
 */
 public struct BayaFrameLayout: BayaLayout, BayaLayoutIterator {
-    public var layoutMargins: UIEdgeInsets
+    public var bayaMargins: UIEdgeInsets
     public var frame: CGRect
     private var elements: [BayaLayoutable]
     private var measures = [CGSize]()
 
     init(
         elements: [BayaLayoutable],
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
         self.elements = elements
-        self.layoutMargins = layoutMargins
+        self.bayaMargins = bayaMargins
         self.frame = CGRect()
     }
 
@@ -32,8 +32,8 @@ public struct BayaFrameLayout: BayaLayout, BayaLayoutIterator {
             let size = BayaFrameLayout.combineSizeForLayout(for: e2, wrappingSize: e2s, matchingSize: frame.size)
             return CGRect(
                 origin: CGPoint(
-                    x: frame.minX + e2.layoutMargins.left,
-                    y: frame.minY + e2.layoutMargins.top),
+                    x: frame.minX + e2.bayaMargins.left,
+                    y: frame.minY + e2.bayaMargins.top),
                 size: size)
         }
     }
@@ -55,19 +55,19 @@ public struct BayaFrameLayout: BayaLayout, BayaLayoutIterator {
 public extension Sequence where Iterator.Element: BayaLayoutable {
     /// Places the elements in a frame. The `BayaFrameLayout` acts as a simple way to group elements and
     /// applies only minimal layout logic.
-    /// - parameter layoutMargins: The layout's margins.
+    /// - parameter bayaMargins: The layout's margins.
     /// - returns: A `BayaFrameLayout`.
-    func layoutAsFrame(layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaFrameLayout {
-        return BayaFrameLayout(elements: self.array(), layoutMargins: layoutMargins)
+    func layoutAsFrame(bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaFrameLayout {
+        return BayaFrameLayout(elements: self.array(), bayaMargins: bayaMargins)
     }
 }
 
 public extension Sequence where Iterator.Element == BayaLayoutable {
     /// Places the elements in a frame. The `BayaFrameLayout` acts as a simple way to group elements and
     /// applies only minimal layout logic.
-    /// - parameter layoutMargins: The layout's margins.
+    /// - parameter bayaMargins: The layout's margins.
     /// - returns: A `BayaFrameLayout`.
-    func layoutAsFrame(layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaFrameLayout {
-        return BayaFrameLayout(elements: self.array(), layoutMargins: layoutMargins)
+    func layoutAsFrame(bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaFrameLayout {
+        return BayaFrameLayout(elements: self.array(), bayaMargins: bayaMargins)
     }
 }

--- a/Baya/layouts/BayaFrameLayout.swift
+++ b/Baya/layouts/BayaFrameLayout.swift
@@ -18,7 +18,7 @@ public struct BayaFrameLayout: BayaLayout, BayaLayoutIterator {
 
     init(
         elements: [BayaLayoutable],
-        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        bayaMargins: UIEdgeInsets) {
         self.elements = elements
         self.bayaMargins = bayaMargins
         self.frame = CGRect()

--- a/Baya/layouts/BayaGravityLayout.swift
+++ b/Baya/layouts/BayaGravityLayout.swift
@@ -11,9 +11,9 @@ import UIKit
     It also assumes layout mode .matchParent for gravitating axis.
 */
 public struct BayaGravityLayout: BayaLayout {
-    public var layoutMargins: UIEdgeInsets = UIEdgeInsets.zero
+    public var bayaMargins: UIEdgeInsets = UIEdgeInsets.zero
     public var frame: CGRect
-    public let layoutModes: BayaLayoutOptions.Modes
+    public let bayaModes: BayaLayoutOptions.Modes
     private var element: BayaLayoutable
     private var measure: CGSize?
     private let horizontalGravity: BayaLayoutOptions.Gravity.Horizontal?
@@ -27,9 +27,9 @@ public struct BayaGravityLayout: BayaLayout {
         self.horizontalGravity = horizontalGravity
         self.verticalGravity = verticalGravity
         self.frame = CGRect()
-        self.layoutModes = BayaLayoutOptions.Modes(
-            width: horizontalGravity != nil ? .matchParent : element.layoutModes.width,
-            height: verticalGravity != nil ? .matchParent : element.layoutModes.height)
+        self.bayaModes = BayaLayoutOptions.Modes(
+            width: horizontalGravity != nil ? .matchParent : element.bayaModes.width,
+            height: verticalGravity != nil ? .matchParent : element.bayaModes.height)
     }
 
     public mutating func layoutWith(frame: CGRect) {
@@ -39,16 +39,16 @@ public struct BayaGravityLayout: BayaLayout {
 
         switch horizontalGravity {
         case .none: fallthrough
-        case .some(.left): point.x = frame.minX + element.layoutMargins.left
+        case .some(.left): point.x = frame.minX + element.bayaMargins.left
         case .some(.centerX): point.x = frame.midX - (size.width * 0.5)
-        case .some(.right): point.x = frame.maxX - size.width - element.layoutMargins.right
+        case .some(.right): point.x = frame.maxX - size.width - element.bayaMargins.right
         }
 
         switch verticalGravity {
         case .none: fallthrough
-        case .some(.top): point.y = frame.minY + element.layoutMargins.top
+        case .some(.top): point.y = frame.minY + element.bayaMargins.top
         case .some(.centerY): point.y = frame.midY - (size.height * 0.5)
-        case .some(.bottom): point.y = frame.maxY - size.height - element.layoutMargins.bottom
+        case .some(.bottom): point.y = frame.maxY - size.height - element.bayaMargins.bottom
         }
 
         element.layoutWith(frame: CGRect(

--- a/Baya/layouts/BayaLinearLayout.swift
+++ b/Baya/layouts/BayaLinearLayout.swift
@@ -11,7 +11,7 @@ import UIKit
     This Layout respects the margins of its children.
 */
 public struct BayaLinearLayout: BayaLayout, BayaLayoutIterator {
-    public var layoutMargins: UIEdgeInsets
+    public var bayaMargins: UIEdgeInsets
     public var frame: CGRect
     var orientation: BayaLayoutOptions.Orientation
     var spacing: CGFloat
@@ -23,10 +23,10 @@ public struct BayaLinearLayout: BayaLayout, BayaLayoutIterator {
         elements: [BayaLayoutable],
         orientation: BayaLayoutOptions.Orientation,
         spacing: CGFloat = 0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
         self.elements = elements
         self.orientation = orientation
-        self.layoutMargins = layoutMargins
+        self.bayaMargins = bayaMargins
         self.spacing = spacing
         self.frame = CGRect()
     }
@@ -49,14 +49,14 @@ public struct BayaLinearLayout: BayaLayout, BayaLayoutIterator {
                 if let e1 = e1 {
                     origin = CGPoint(
                         x: e1.frame.maxX
-                            + e1.layoutMargins.right
+                            + e1.bayaMargins.right
                             + spacing
-                            + e2.layoutMargins.left,
-                        y: frame.minY + e2.layoutMargins.top)
+                            + e2.bayaMargins.left,
+                        y: frame.minY + e2.bayaMargins.top)
                 } else {
                     origin = CGPoint(
-                        x: frame.minX + e2.layoutMargins.left,
-                        y: frame.minY + e2.layoutMargins.top)
+                        x: frame.minX + e2.bayaMargins.left,
+                        y: frame.minY + e2.bayaMargins.top)
                 }
                 return CGRect(origin: origin, size: size)
             }
@@ -70,15 +70,15 @@ public struct BayaLinearLayout: BayaLayout, BayaLayoutIterator {
                 let origin: CGPoint
                 if let e1 = e1 {
                     origin = CGPoint(
-                        x: frame.minX + e2.layoutMargins.left,
+                        x: frame.minX + e2.bayaMargins.left,
                         y: e1.frame.maxY
-                            + e1.layoutMargins.bottom
+                            + e1.bayaMargins.bottom
                             + spacing
-                            + e2.layoutMargins.top)
+                            + e2.bayaMargins.top)
                 } else {
                     origin = CGPoint(
-                        x: frame.minX + e2.layoutMargins.left,
-                        y: frame.minY + e2.layoutMargins.top)
+                        x: frame.minX + e2.bayaMargins.left,
+                        y: frame.minY + e2.bayaMargins.top)
                 }
                 return CGRect(origin: origin, size: size)
             }
@@ -95,10 +95,10 @@ public struct BayaLinearLayout: BayaLayout, BayaLayoutIterator {
             for i in 0..<elements.count {
                 let fit = measures[i]
                 let element = elements[i]
-                resultSize.width += fit.width + element.layoutMargins.left + element.layoutMargins.right
+                resultSize.width += fit.width + element.bayaMargins.left + element.bayaMargins.right
                 resultSize.height = max(
                     resultSize.height,
-                    fit.height + element.layoutMargins.top + element.layoutMargins.bottom)
+                    fit.height + element.bayaMargins.top + element.bayaMargins.bottom)
             }
         case .vertical:
             let elementCount = elements.count
@@ -108,8 +108,8 @@ public struct BayaLinearLayout: BayaLayout, BayaLayoutIterator {
                 let element = elements[i]
                 resultSize.width = max(
                     resultSize.width,
-                    fit.width + element.layoutMargins.left + element.layoutMargins.right)
-                resultSize.height += fit.height + element.layoutMargins.top + element.layoutMargins.bottom
+                    fit.width + element.bayaMargins.left + element.bayaMargins.right)
+                resultSize.height += fit.height + element.bayaMargins.top + element.bayaMargins.bottom
             }
         }
         return resultSize
@@ -123,14 +123,14 @@ public struct BayaLinearLayout: BayaLayout, BayaLayoutIterator {
             -> CGSize {
         switch orientation {
         case .horizontal:
-            guard element.layoutModes.height == .matchParent else {
+            guard element.bayaModes.height == .matchParent else {
                 return cachedSize
             }
             return CGSize(
                 width: cachedSize.width,
                 height: availableSize.height - element.verticalMargins)
         case .vertical:
-            guard element.layoutModes.width == .matchParent else {
+            guard element.bayaModes.width == .matchParent else {
                 return cachedSize
             }
             return CGSize(
@@ -144,18 +144,18 @@ public extension Sequence where Iterator.Element: BayaLayoutable {
     /// Aligns all elements in a single direction.
     /// - parameter orientation: Determines if the elements should be laid out in horizontal or vertical direction.
     /// - parameter spacing: The gap between the elements.
-    /// - parameter layoutMargins: The layout's margins.
+    /// - parameter bayaMargins: The layout's margins.
     /// - returns: A `BayaLinearLayout`.
     func layoutLinearly(
         orientation: BayaLayoutOptions.Orientation,
         spacing: CGFloat = 0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero)
             -> BayaLinearLayout {
         return BayaLinearLayout(
             elements: self.array(),
             orientation: orientation,
             spacing: spacing,
-            layoutMargins: layoutMargins)
+            bayaMargins: bayaMargins)
     }
 }
 
@@ -163,17 +163,17 @@ public extension Sequence where Iterator.Element == BayaLayoutable {
     /// Aligns all elements in a single direction.
     /// - parameter orientation: Determines if the elements should be laid out in horizontal or vertical direction.
     /// - parameter spacing: The gap between the elements.
-    /// - parameter layoutMargins: The layout's margins.
+    /// - parameter bayaMargins: The layout's margins.
     /// - returns: A `BayaLinearLayout`.
     func layoutLinearly(
         orientation: BayaLayoutOptions.Orientation,
         spacing: CGFloat = 0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero)
             -> BayaLinearLayout {
         return BayaLinearLayout(
             elements: self.array(),
             orientation: orientation,
             spacing: spacing,
-            layoutMargins: layoutMargins)
+            bayaMargins: bayaMargins)
     }
 }

--- a/Baya/layouts/BayaLinearLayout.swift
+++ b/Baya/layouts/BayaLinearLayout.swift
@@ -23,7 +23,7 @@ public struct BayaLinearLayout: BayaLayout, BayaLayoutIterator {
         elements: [BayaLayoutable],
         orientation: BayaLayoutOptions.Orientation,
         spacing: CGFloat = 0,
-        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        bayaMargins: UIEdgeInsets) {
         self.elements = elements
         self.orientation = orientation
         self.bayaMargins = bayaMargins

--- a/Baya/layouts/BayaMarginsLayout.swift
+++ b/Baya/layouts/BayaMarginsLayout.swift
@@ -46,14 +46,3 @@ public extension BayaLayoutable {
             bayaMargins: bayaMargins)
     }
 }
-
-extension UIViewController {
-    /// Enables full control over the root view's margins by wrapping it in a `BayaMarginsLayout`.
-    /// The `bayaMargins` of `UIViewController`s' root views are managed by the system, and cannot be changed.
-    /// To prevent unwanted layout behavior, use this function.
-    /// - parameter bayaMargins: The desired `bayaMargins` around the view.
-    /// - returns: A `BayaMarginsLayout` containing the `UIViewController`'s root view.
-    public func getRootViewAsLayoutable(with bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaLayoutable {
-        return view.layoutWithMargins(bayaMargins: bayaMargins)
-    }
-}

--- a/Baya/layouts/BayaMarginsLayout.swift
+++ b/Baya/layouts/BayaMarginsLayout.swift
@@ -8,23 +8,23 @@ import Foundation
 /**
     This Layout should only be used on Layoutables whose margins cannot be controlled otherwise, 
     for example the root view of an UIViewController.
-    Mirrors the child's layoutModes and frame.
+    Mirrors the child's bayaModes and frame.
  */
 public struct BayaMarginsLayout: BayaLayout {
-    public var layoutModes: BayaLayoutOptions.Modes {
-        return element.layoutModes
+    public var bayaModes: BayaLayoutOptions.Modes {
+        return element.bayaModes
     }
     public var frame: CGRect {
         return element.frame
     }
-    public var layoutMargins: UIEdgeInsets
+    public var bayaMargins: UIEdgeInsets
     private var element: BayaLayoutable
     
     init(
         element: BayaLayoutable,
-        layoutMargins: UIEdgeInsets) {
+        bayaMargins: UIEdgeInsets) {
         self.element = element
-        self.layoutMargins = layoutMargins
+        self.bayaMargins = bayaMargins
     }
 
     public mutating func layoutWith(frame: CGRect) {
@@ -38,22 +38,22 @@ public struct BayaMarginsLayout: BayaLayout {
 
 public extension BayaLayoutable {
     /// Disregards the element's margins and substitutes them with the margins passed as parameter.
-    /// - parameter layoutMargins: The layout's margins.
+    /// - parameter bayaMargins: The layout's margins.
     /// - returns: A `BayaMarginsLayout`.
-    func layoutWithMargins(layoutMargins: UIEdgeInsets) -> BayaMarginsLayout {
+    func layoutWithMargins(bayaMargins: UIEdgeInsets) -> BayaMarginsLayout {
         return BayaMarginsLayout(
             element: self,
-            layoutMargins: layoutMargins)
+            bayaMargins: bayaMargins)
     }
 }
 
 extension UIViewController {
     /// Enables full control over the root view's margins by wrapping it in a `BayaMarginsLayout`.
-    /// The `layoutMargins` of `UIViewController`s' root views are managed by the system, and cannot be changed.
+    /// The `bayaMargins` of `UIViewController`s' root views are managed by the system, and cannot be changed.
     /// To prevent unwanted layout behavior, use this function.
-    /// - parameter layoutMargins: The desired `layoutMargins` around the view.
+    /// - parameter bayaMargins: The desired `bayaMargins` around the view.
     /// - returns: A `BayaMarginsLayout` containing the `UIViewController`'s root view.
-    public func getRootViewAsLayoutable(with layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaLayoutable {
-        return view.layoutWithMargins(layoutMargins: layoutMargins)
+    public func getRootViewAsLayoutable(with bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) -> BayaLayoutable {
+        return view.layoutWithMargins(bayaMargins: bayaMargins)
     }
 }

--- a/Baya/layouts/BayaMatchParentLayout.swift
+++ b/Baya/layouts/BayaMatchParentLayout.swift
@@ -11,21 +11,21 @@ import UIKit
     Mirrors layout modes and frame from its child.
  */
 public struct BayaMatchParentLayout: BayaLayout {
-    public var layoutMargins: UIEdgeInsets {
-        return element.layoutMargins
+    public var bayaMargins: UIEdgeInsets {
+        return element.bayaMargins
     }
     public var frame: CGRect {
         return element.frame;
     }
-    public var layoutModes: BayaLayoutOptions.Modes = BayaLayoutOptions.Modes.default
+    public var bayaModes: BayaLayoutOptions.Modes = BayaLayoutOptions.Modes.default
 
     private var element: BayaLayoutable
 
     init(
         element: BayaLayoutable,
-        layoutModes: BayaLayoutOptions.Modes) {
+        bayaModes: BayaLayoutOptions.Modes) {
         self.element = element
-        self.layoutModes = layoutModes
+        self.bayaModes = bayaModes
     }
 
     mutating public func layoutWith(frame: CGRect) {
@@ -43,7 +43,7 @@ public extension BayaLayoutable {
     func layoutMatchingParentWidth() -> BayaLayout {
         return BayaMatchParentLayout(
             element: self,
-            layoutModes: BayaLayoutOptions.Modes(
+            bayaModes: BayaLayoutOptions.Modes(
                 width: .matchParent,
                 height: .wrapContent))
     }
@@ -53,7 +53,7 @@ public extension BayaLayoutable {
     func layoutMatchingParentHeight() -> BayaLayout {
         return BayaMatchParentLayout(
             element: self,
-            layoutModes: BayaLayoutOptions.Modes(
+            bayaModes: BayaLayoutOptions.Modes(
                 width: .wrapContent,
                 height: .matchParent))
     }
@@ -64,7 +64,7 @@ public extension BayaLayoutable {
             -> BayaLayout {
         return BayaMatchParentLayout(
             element: self,
-            layoutModes: BayaLayoutOptions.Modes(
+            bayaModes: BayaLayoutOptions.Modes(
                 width: .matchParent,
                 height: .matchParent))
     }

--- a/Baya/layouts/BayaOriginResetLayout.swift
+++ b/Baya/layouts/BayaOriginResetLayout.swift
@@ -8,17 +8,17 @@ import UIKit
 
 /**
     Sets the origin of a given element to x: 0, y: 0. Handy when laying out views in deeper view hierarchies.
-    Mirrors frame, layoutMargins and layoutModes from its child.
+    Mirrors frame, bayaMargins and bayaModes from its child.
 */
 public struct BayaOriginResetLayout: BayaLayout {
-    public var layoutMargins: UIEdgeInsets {
-        return element.layoutMargins
+    public var bayaMargins: UIEdgeInsets {
+        return element.bayaMargins
     }
     public var frame: CGRect {
         return element.frame
     }
-    public var layoutModes: BayaLayoutOptions.Modes {
-        return element.layoutModes
+    public var bayaModes: BayaLayoutOptions.Modes {
+        return element.bayaModes
     }
     private var element: BayaLayoutable
 

--- a/Baya/layouts/BayaPagedScrollLayout.swift
+++ b/Baya/layouts/BayaPagedScrollLayout.swift
@@ -12,7 +12,7 @@ import UIKit
     This layout assumes that its child has the implicit layout mode .matchParent.
  */
 public struct BayaPagedScrollLayout: BayaLayout {
-    public var layoutMargins: UIEdgeInsets
+    public var bayaMargins: UIEdgeInsets
     public var frame: CGRect
     var orientation: BayaLayoutOptions.Orientation
     var pages: Int
@@ -27,13 +27,13 @@ public struct BayaPagedScrollLayout: BayaLayout {
         pages: Int,
         spacing: CGFloat = 0,
         orientation: BayaLayoutOptions.Orientation = .horizontal,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
         self.content = content
         self.container = container
         self.pages = pages
         self.spacing = spacing
         self.orientation = orientation
-        self.layoutMargins = layoutMargins
+        self.bayaMargins = bayaMargins
         self.frame = CGRect()
     }
 
@@ -75,14 +75,14 @@ public extension BayaLayoutable {
     /// - parameter pages: Determines the size of the element.
     /// - parameter spacing: The gap between the pages.
     /// - parameter orientation: Determines if the pages are laid out in horizontal or vertical direction.
-    /// - parameter layoutMargins: The layout's margins.
+    /// - parameter bayaMargins: The layout's margins.
     /// - returns: A `BayaPagedScrollLayout`.
     func layoutPagedScrollContent(
         container: BayaScrollLayoutContainer,
         pages: Int,
         spacing: CGFloat = 0,
         orientation: BayaLayoutOptions.Orientation = .horizontal,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero)
             -> BayaPagedScrollLayout {
         return BayaPagedScrollLayout(
             content: self,
@@ -90,6 +90,6 @@ public extension BayaLayoutable {
             pages: pages,
             spacing: spacing,
             orientation: orientation,
-            layoutMargins: layoutMargins)
+            bayaMargins: bayaMargins)
     }
 }

--- a/Baya/layouts/BayaPagedScrollLayout.swift
+++ b/Baya/layouts/BayaPagedScrollLayout.swift
@@ -25,9 +25,9 @@ public struct BayaPagedScrollLayout: BayaLayout {
         content: BayaLayoutable,
         container: BayaScrollLayoutContainer,
         pages: Int,
-        spacing: CGFloat = 0,
-        orientation: BayaLayoutOptions.Orientation = .horizontal,
-        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        spacing: CGFloat,
+        orientation: BayaLayoutOptions.Orientation,
+        bayaMargins: UIEdgeInsets) {
         self.content = content
         self.container = container
         self.pages = pages

--- a/Baya/layouts/BayaProportionalSizeLayout.swift
+++ b/Baya/layouts/BayaProportionalSizeLayout.swift
@@ -9,18 +9,18 @@ import UIKit
 /**
     A Layout that uses a portion of the given size for measurement and layout.
     Mirrors frame and layoutMargin from its child.
-    Overrides layoutModes so that proportional axis are wrapContent.
+    Overrides bayaModes so that proportional axis are wrapContent.
  */
 public struct BayaProportionalSizeLayout: BayaLayout {
-    public var layoutMargins: UIEdgeInsets {
-        return element.layoutMargins
+    public var bayaMargins: UIEdgeInsets {
+        return element.bayaMargins
     }
     public var frame: CGRect {
         return element.frame
     }
     private var element: BayaLayoutable
     private var measure: CGSize?
-    public let layoutModes: BayaLayoutOptions.Modes
+    public let bayaModes: BayaLayoutOptions.Modes
     private var widthFactor: CGFloat?
     private var heightFactor: CGFloat?
 
@@ -31,9 +31,9 @@ public struct BayaProportionalSizeLayout: BayaLayout {
         self.element = element
         self.widthFactor = widthFactor.defaultToOneIfLarger()
         self.heightFactor = heightFactor.defaultToOneIfLarger()
-        layoutModes = BayaLayoutOptions.Modes(
-            width: widthFactor != nil ? .wrapContent : element.layoutModes.width,
-            height: heightFactor != nil ? .wrapContent : element.layoutModes.height)
+        bayaModes = BayaLayoutOptions.Modes(
+            width: widthFactor != nil ? .wrapContent : element.bayaModes.width,
+            height: heightFactor != nil ? .wrapContent : element.bayaModes.height)
     }
 
     public mutating func layoutWith(frame: CGRect) {
@@ -48,10 +48,10 @@ public struct BayaProportionalSizeLayout: BayaLayout {
         // Only if a side has no portion factor and the layoutMode .matchParent it should actually
         // match the parent.
         let size = CGSize(
-            width: widthFactor != nil || element.layoutModes.width == .wrapContent ?
+            width: widthFactor != nil || element.bayaModes.width == .wrapContent ?
                 measure.width :
                 frame.subtractMargins(ofElement: element).width,
-            height: heightFactor != nil || element.layoutModes.height == .wrapContent ?
+            height: heightFactor != nil || element.bayaModes.height == .wrapContent ?
                 measure.height :
                 frame.subtractMargins(ofElement: element).height)
 
@@ -83,9 +83,9 @@ private extension Optional where Wrapped == CGFloat {
 public extension BayaLayoutable {
     /// Sets a portion of the available size as the size of the element.
     /// - parameter widthFactor: A factor from 0 to 1, which (multiplied by the available width) defines the width of the
-    ///   element. If `nil` is passed as parameter the width is determined in accordance with the element's `layoutModes`.
+    ///   element. If `nil` is passed as parameter the width is determined in accordance with the element's `bayaModes`.
     /// - parameter heightFactor: A factor from 0 to 1, which (multiplied by the available height) defines the height of
-    ///   the element. If `nil` is passed as parameter the height is determined in accordance with the element's `layoutModes`.
+    ///   the element. If `nil` is passed as parameter the height is determined in accordance with the element's `bayaModes`.
     /// - returns: A `BayaProportionalSizeLayout`.
     func layoutWithPortion(
         ofWidth widthFactor: CGFloat? = nil,

--- a/Baya/layouts/BayaProportionalSizeLayout.swift
+++ b/Baya/layouts/BayaProportionalSizeLayout.swift
@@ -26,8 +26,8 @@ public struct BayaProportionalSizeLayout: BayaLayout {
 
     init(
         element: BayaLayoutable,
-        widthFactor: CGFloat? = nil,
-        heightFactor: CGFloat? = nil) {
+        widthFactor: CGFloat?,
+        heightFactor: CGFloat?) {
         self.element = element
         self.widthFactor = widthFactor.defaultToOneIfLarger()
         self.heightFactor = heightFactor.defaultToOneIfLarger()

--- a/Baya/layouts/BayaScrollLayout.swift
+++ b/Baya/layouts/BayaScrollLayout.swift
@@ -22,8 +22,8 @@ public struct BayaScrollLayout: BayaLayout {
     init(
         content: BayaLayoutable,
         container: BayaScrollLayoutContainer,
-        orientation: BayaLayoutOptions.Orientation = .vertical,
-        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        orientation: BayaLayoutOptions.Orientation,
+        bayaMargins: UIEdgeInsets) {
         self.content = content
         self.container = container
         self.orientation = orientation

--- a/Baya/layouts/BayaScrollLayout.swift
+++ b/Baya/layouts/BayaScrollLayout.swift
@@ -10,9 +10,9 @@ import UIKit
     A Layout for a ScrollContainer and its content.
 */
 public struct BayaScrollLayout: BayaLayout {
-    public var layoutMargins: UIEdgeInsets
+    public var bayaMargins: UIEdgeInsets
     public var frame: CGRect
-    public let layoutModes: BayaLayoutOptions.Modes
+    public let bayaModes: BayaLayoutOptions.Modes
     var orientation: BayaLayoutOptions.Orientation
 
     private var container: BayaScrollLayoutContainer
@@ -23,16 +23,16 @@ public struct BayaScrollLayout: BayaLayout {
         content: BayaLayoutable,
         container: BayaScrollLayoutContainer,
         orientation: BayaLayoutOptions.Orientation = .vertical,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero) {
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero) {
         self.content = content
         self.container = container
         self.orientation = orientation
-        self.layoutMargins = layoutMargins
+        self.bayaMargins = bayaMargins
         self.frame = CGRect()
-        self.layoutModes = BayaLayoutOptions.Modes(
-            width: content.layoutModes.width == .wrapContent && container.layoutModes.width == .wrapContent ?
+        self.bayaModes = BayaLayoutOptions.Modes(
+            width: content.bayaModes.width == .wrapContent && container.bayaModes.width == .wrapContent ?
                 .wrapContent : .matchParent,
-            height: content.layoutModes.height == .wrapContent && container.layoutModes.height == .wrapContent ?
+            height: content.bayaModes.height == .wrapContent && container.bayaModes.height == .wrapContent ?
                 .wrapContent : .matchParent)
     }
 
@@ -44,27 +44,27 @@ public struct BayaScrollLayout: BayaLayout {
         switch orientation {
         case .horizontal:
             adjustedContentSize = CGSize(
-                width: content.layoutModes.width == .wrapContent ?
+                width: content.bayaModes.width == .wrapContent ?
                     measuredContentSize.width : max(
                         measuredContentSize.width,
                         frame.size.width - container.horizontalMargins - content.horizontalMargins),
-                height: content.layoutModes.height == .wrapContent ?
+                height: content.bayaModes.height == .wrapContent ?
                     measuredContentSize.height : frame.height - content.verticalMargins - container.verticalMargins)
         case .vertical:
             adjustedContentSize = CGSize(
-                width: content.layoutModes.width == .wrapContent ?
+                width: content.bayaModes.width == .wrapContent ?
                     measuredContentSize.width : frame.width - content.horizontalMargins - container.horizontalMargins,
-                height: content.layoutModes.height == .wrapContent ?
+                height: content.bayaModes.height == .wrapContent ?
                     measuredContentSize.height : max(
                         measuredContentSize.height,
                         frame.size.height - container.verticalMargins - content.verticalMargins)
             )
         }
-        let layoutMargins = content.layoutMargins
+        let bayaMargins = content.bayaMargins
         content.layoutWith(frame: CGRect(
             origin: CGPoint(
-                x: layoutMargins.left,
-                y: layoutMargins.top),
+                x: bayaMargins.left,
+                y: bayaMargins.top),
             size: adjustedContentSize))
         container.layoutWith(frame: frame.subtractMargins(ofElement: container))
         container.contentSize = adjustedContentSize.addMargins(ofElement: content)
@@ -99,17 +99,17 @@ public extension BayaLayoutable {
     ///   of the container.
     /// - parameter orientation: Determines the direction in which the element is allowed to extend past the
     ///   container. This is the direction that may be scrolled, if the element is large enough.
-    /// - parameter layoutMargins: The margins around the container.
+    /// - parameter bayaMargins: The margins around the container.
     /// - returns: A `BayaScrollLayout`.
     func layoutScrollContent(
         container: BayaScrollLayoutContainer,
         orientation: BayaLayoutOptions.Orientation = .vertical,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero)
+        bayaMargins: UIEdgeInsets = UIEdgeInsets.zero)
             -> BayaScrollLayout {
         return BayaScrollLayout(
             content: self,
             container: container,
             orientation: orientation,
-            layoutMargins: layoutMargins)
+            bayaMargins: bayaMargins)
     }
 }

--- a/Baya/layouts/BayaSquareLayout.swift
+++ b/Baya/layouts/BayaSquareLayout.swift
@@ -8,17 +8,17 @@ import UIKit
 
 /**
     Layout that uses only the reference side for measurement, or the bigger side if not specified.
-    Mirrors layoutMargins and frame of its child.
+    Mirrors bayaMargins and frame of its child.
     When setting the frame of its element, it uses the smaller side to ensure the square fits in the available space.
 */
 public struct BayaSquareLayout: BayaLayout {
-    public var layoutMargins: UIEdgeInsets {
-        return element.layoutMargins
+    public var bayaMargins: UIEdgeInsets {
+        return element.bayaMargins
     }
     public var frame: CGRect {
         return element.frame
     }
-    public var layoutModes: BayaLayoutOptions.Modes {
+    public var bayaModes: BayaLayoutOptions.Modes {
         // BayaSquareLayout wants its parent to used the measured sizes.
         return BayaLayoutOptions.Modes.default
     }

--- a/BayaTests/BayaEqualSegmentsTests.swift
+++ b/BayaTests/BayaEqualSegmentsTests.swift
@@ -59,32 +59,32 @@ class BayaEqualSegmentsTests: XCTestCase {
         let availableSideLength = (l3.width + l3.horizontalMargins) // Largest element as base.
 
         XCTAssertEqual(l1.frame, CGRect(
-            x: layoutRect.origin.x + l1.layoutMargins.left,
-            y: layoutRect.origin.y + l1.layoutMargins.top,
+            x: layoutRect.origin.x + l1.bayaMargins.left,
+            y: layoutRect.origin.y + l1.bayaMargins.top,
             width: l1.width,
             height: l1.height))
         XCTAssertEqual(l2.frame, CGRect(
             x: layoutRect.origin.x
                 + availableSideLength
                 + spacing
-                + l2.layoutMargins.left,
-            y: layoutRect.origin.y + l2.layoutMargins.top,
+                + l2.bayaMargins.left,
+            y: layoutRect.origin.y + l2.bayaMargins.top,
             width: l2.width,
             height: l2.height))
         XCTAssertEqual(l3.frame,CGRect(
             x: layoutRect.origin.x
                 + availableSideLength * 2
                 + spacing * 2
-                + l3.layoutMargins.left,
-            y: layoutRect.origin.y + l3.layoutMargins.top,
+                + l3.bayaMargins.left,
+            y: layoutRect.origin.y + l3.bayaMargins.top,
             width: l3.width,
             height: l3.height))
     }
     
     func testHorizontalMatchingParent() {
-        l1 = TestLayoutable(sideLength: 30, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 60, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 90, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 30, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 60, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 90, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         l1.m(1, 2, 3, 4)
         l2.m(5, 6, 7, 8)
         l3.m(9, 10, 11, 12)
@@ -106,8 +106,8 @@ class BayaEqualSegmentsTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRect.minX + l1.layoutMargins.left,
-                y: layoutRect.minY + l1.layoutMargins.top,
+                x: layoutRect.minX + l1.bayaMargins.left,
+                y: layoutRect.minY + l1.bayaMargins.top,
                 width: maxWidth - l1.horizontalMargins,
                 height: maxHeight - l1.verticalMargins))
         XCTAssertEqual(
@@ -116,8 +116,8 @@ class BayaEqualSegmentsTests: XCTestCase {
                 x: layoutRect.minX
                     + maxWidth
                     + spacing
-                    + l2.layoutMargins.left,
-                y: layoutRect.minY + l2.layoutMargins.top,
+                    + l2.bayaMargins.left,
+                y: layoutRect.minY + l2.bayaMargins.top,
                 width: maxWidth - l2.horizontalMargins,
                 height: maxHeight - l2.verticalMargins))
         XCTAssertEqual(
@@ -126,8 +126,8 @@ class BayaEqualSegmentsTests: XCTestCase {
                 x: layoutRect.minX
                     + maxWidth * 2
                     + spacing * 2
-                    + l3.layoutMargins.left,
-                y: layoutRect.minY + l3.layoutMargins.top,
+                    + l3.bayaMargins.left,
+                y: layoutRect.minY + l3.bayaMargins.top,
                 width: maxWidth - l3.horizontalMargins,
                 height: maxHeight - l3.verticalMargins))
     }
@@ -144,8 +144,8 @@ class BayaEqualSegmentsTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRect.minX + l1.layoutMargins.left,
-                y: layoutRect.minY + l1.layoutMargins.top,
+                x: layoutRect.minX + l1.bayaMargins.left,
+                y: layoutRect.minY + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height))
         XCTAssertEqual(
@@ -154,8 +154,8 @@ class BayaEqualSegmentsTests: XCTestCase {
                 x: layoutRect.minX
                     + availableSideLength
                     + spacing
-                    + l2.layoutMargins.left,
-                y: layoutRect.minY + l2.layoutMargins.top,
+                    + l2.bayaMargins.left,
+                y: layoutRect.minY + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
         XCTAssertEqual(
@@ -164,16 +164,16 @@ class BayaEqualSegmentsTests: XCTestCase {
                 x: layoutRect.minX
                     + availableSideLength * 2
                     + spacing * 2
-                    + l3.layoutMargins.left,
-                y: layoutRect.minY + l3.layoutMargins.top,
+                    + l3.bayaMargins.left,
+                y: layoutRect.minY + l3.bayaMargins.top,
                 width: l3.width,
                 height: l3.height))
     }
     
     func testHorizontalBigEnforcedFrameMatchingParent() {
-        l1 = TestLayoutable(sideLength: 30, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 60, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 90, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 30, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 60, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 90, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         l1.m(1, 2, 3, 4)
         l2.m(5, 6, 7, 8)
         l3.m(9, 10, 11, 12)
@@ -189,8 +189,8 @@ class BayaEqualSegmentsTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRect.minX + l1.layoutMargins.left,
-                y: layoutRect.minY + l1.layoutMargins.top,
+                x: layoutRect.minX + l1.bayaMargins.left,
+                y: layoutRect.minY + l1.bayaMargins.top,
                 width: availableSideLength - l1.horizontalMargins,
                 height: layoutRect.height - l1.verticalMargins))
         XCTAssertEqual(
@@ -199,8 +199,8 @@ class BayaEqualSegmentsTests: XCTestCase {
                 x: layoutRect.minX
                     + availableSideLength
                     + spacing
-                    + l2.layoutMargins.left,
-                y: layoutRect.minY + l2.layoutMargins.top,
+                    + l2.bayaMargins.left,
+                y: layoutRect.minY + l2.bayaMargins.top,
                 width: availableSideLength - l2.horizontalMargins,
                 height: layoutRect.height - l2.verticalMargins))
         XCTAssertEqual(
@@ -209,8 +209,8 @@ class BayaEqualSegmentsTests: XCTestCase {
                 x: layoutRect.minX
                     + availableSideLength * 2
                     + spacing * 2
-                    + l3.layoutMargins.left,
-                y: layoutRect.minY + l3.layoutMargins.top,
+                    + l3.bayaMargins.left,
+                y: layoutRect.minY + l3.bayaMargins.top,
                 width: availableSideLength - l3.horizontalMargins,
                 height: layoutRect.height - l3.verticalMargins))
     }
@@ -227,8 +227,8 @@ class BayaEqualSegmentsTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRectTooSmall.origin.x + l1.layoutMargins.left,
-                y: layoutRectTooSmall.origin.y + l1.layoutMargins.top,
+                x: layoutRectTooSmall.origin.x + l1.bayaMargins.left,
+                y: layoutRectTooSmall.origin.y + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height))
         XCTAssertEqual(
@@ -237,8 +237,8 @@ class BayaEqualSegmentsTests: XCTestCase {
                 x: layoutRectTooSmall.origin.x
                     + availableSideLength
                     + spacing
-                    + l2.layoutMargins.left,
-                y: layoutRectTooSmall.origin.y + l2.layoutMargins.top,
+                    + l2.bayaMargins.left,
+                y: layoutRectTooSmall.origin.y + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
         XCTAssertEqual(
@@ -247,16 +247,16 @@ class BayaEqualSegmentsTests: XCTestCase {
                 x: layoutRectTooSmall.origin.x
                     + availableSideLength * 2
                     + spacing * 2
-                    + l3.layoutMargins.left,
-                y: layoutRectTooSmall.origin.y + l3.layoutMargins.top,
+                    + l3.bayaMargins.left,
+                y: layoutRectTooSmall.origin.y + l3.bayaMargins.top,
                 width: l3.width,
                 height: l3.height))
     }
     
     func testHorizontalSmallEnforcedFrameMatchingParent() {
-        l1 = TestLayoutable(sideLength: 30, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 60, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 90, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 30, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 60, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 90, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         var layout = [l1, l2, l3]
             .layoutAsEqualSegments(
                 orientation: .horizontal,
@@ -273,8 +273,8 @@ class BayaEqualSegmentsTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRectTooSmall.origin.x + l1.layoutMargins.left,
-                y: layoutRectTooSmall.origin.y + l1.layoutMargins.top,
+                x: layoutRectTooSmall.origin.x + l1.bayaMargins.left,
+                y: layoutRectTooSmall.origin.y + l1.bayaMargins.top,
                 width: availableSideLength - l1.horizontalMargins,
                 height: maxHeight - l1.verticalMargins))
         XCTAssertEqual(
@@ -283,8 +283,8 @@ class BayaEqualSegmentsTests: XCTestCase {
                 x: layoutRectTooSmall.origin.x
                     + availableSideLength
                     + spacing
-                    + l2.layoutMargins.left,
-                y: layoutRectTooSmall.origin.y + l2.layoutMargins.top,
+                    + l2.bayaMargins.left,
+                y: layoutRectTooSmall.origin.y + l2.bayaMargins.top,
                 width: availableSideLength - l2.horizontalMargins,
                 height: maxHeight - l2.verticalMargins))
         XCTAssertEqual(
@@ -293,8 +293,8 @@ class BayaEqualSegmentsTests: XCTestCase {
                 x: layoutRectTooSmall.origin.x
                     + availableSideLength * 2
                     + spacing * 2
-                    + l3.layoutMargins.left,
-                y: layoutRectTooSmall.origin.y + l3.layoutMargins.top,
+                    + l3.bayaMargins.left,
+                y: layoutRectTooSmall.origin.y + l3.bayaMargins.top,
                 width: availableSideLength - l3.horizontalMargins,
                 height: maxHeight - l3.verticalMargins))
     }
@@ -312,36 +312,36 @@ class BayaEqualSegmentsTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRect.origin.x + l1.layoutMargins.left,
-                y: layoutRect.origin.y + l1.layoutMargins.top,
+                x: layoutRect.origin.x + l1.bayaMargins.left,
+                y: layoutRect.origin.y + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height))
         XCTAssertEqual(
             l2.frame,
             CGRect(
-                x: layoutRect.origin.x + l2.layoutMargins.left,
+                x: layoutRect.origin.x + l2.bayaMargins.left,
                 y: layoutRect.origin.y
                     + availableSideLength
                     + spacing
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
         XCTAssertEqual(
             l3.frame,
             CGRect(
-                x: layoutRect.origin.x + l3.layoutMargins.left,
+                x: layoutRect.origin.x + l3.bayaMargins.left,
                 y: layoutRect.origin.y
                     + availableSideLength * 2
                     + spacing * 2
-                    + l3.layoutMargins.top,
+                    + l3.bayaMargins.top,
                 width: l3.width,
                 height: l3.height))
     }
 
     func testVerticalMatchingParent() {
-        l1 = TestLayoutable(sideLength: 30, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 60, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 90, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 30, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 60, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 90, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         var layout = [l1, l2, l3]
             .layoutAsEqualSegments(
             orientation: .vertical,
@@ -360,28 +360,28 @@ class BayaEqualSegmentsTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRect.minX + l1.layoutMargins.left,
-                y: layoutRect.minY + l1.layoutMargins.top,
+                x: layoutRect.minX + l1.bayaMargins.left,
+                y: layoutRect.minY + l1.bayaMargins.top,
                 width: maxWidth - l1.horizontalMargins,
                 height: maxHeight - l1.verticalMargins))
         XCTAssertEqual(
             l2.frame,
             CGRect(
-                x: layoutRect.minX + l2.layoutMargins.left,
+                x: layoutRect.minX + l2.bayaMargins.left,
                 y: layoutRect.minY
                     + maxHeight
                     + spacing
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: maxWidth - l2.horizontalMargins,
                 height: maxHeight - l2.verticalMargins))
         XCTAssertEqual(
             l3.frame,
             CGRect(
-                x: layoutRect.minX + l3.layoutMargins.left,
+                x: layoutRect.minX + l3.bayaMargins.left,
                 y: layoutRect.minY
                     + maxHeight * 2
                     + spacing * 2
-                    + l3.layoutMargins.top,
+                    + l3.bayaMargins.top,
                 width: maxWidth - l3.horizontalMargins,
                 height: maxHeight - l3.verticalMargins))
     }
@@ -398,36 +398,36 @@ class BayaEqualSegmentsTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRect.minX + l1.layoutMargins.left,
-                y: layoutRect.minY + l1.layoutMargins.top,
+                x: layoutRect.minX + l1.bayaMargins.left,
+                y: layoutRect.minY + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height))
         XCTAssertEqual(
             l2.frame,
             CGRect(
-                x: layoutRect.minX + l2.layoutMargins.left,
+                x: layoutRect.minX + l2.bayaMargins.left,
                 y: layoutRect.minY
                     + availableSideLength
                     + spacing
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
         XCTAssertEqual(
             l3.frame,
             CGRect(
-                x: layoutRect.minX + l3.layoutMargins.left,
+                x: layoutRect.minX + l3.bayaMargins.left,
                 y: layoutRect.minY
                     + availableSideLength * 2
                     + spacing * 2
-                    + l3.layoutMargins.top,
+                    + l3.bayaMargins.top,
                 width: l3.width,
                 height: l3.height))
     }
 
     func testVerticalBigEnforcedFrameMatchingParent() {
-        l1 = TestLayoutable(sideLength: 30, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 60, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 90, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 30, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 60, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 90, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         l1.m(1, 2, 3, 4)
         l2.m(5, 6, 7, 8)
         l3.m(9, 10, 11, 12)
@@ -444,28 +444,28 @@ class BayaEqualSegmentsTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRect.minX + l1.layoutMargins.left,
-                y: layoutRect.minY + l1.layoutMargins.top,
+                x: layoutRect.minX + l1.bayaMargins.left,
+                y: layoutRect.minY + l1.bayaMargins.top,
                 width: layoutRect.width - l1.horizontalMargins,
                 height: availableSideLength - l1.verticalMargins))
         XCTAssertEqual(
             l2.frame,
             CGRect(
-                x: layoutRect.minX + l2.layoutMargins.left,
+                x: layoutRect.minX + l2.bayaMargins.left,
                 y: layoutRect.minY
                     + availableSideLength
                     + spacing
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: layoutRect.width - l2.horizontalMargins,
                 height: availableSideLength - l2.verticalMargins))
         XCTAssertEqual(
             l3.frame,
             CGRect(
-                x: layoutRect.minX + l3.layoutMargins.left,
+                x: layoutRect.minX + l3.bayaMargins.left,
                 y: layoutRect.minY
                     + availableSideLength * 2
                     + spacing * 2
-                    + l3.layoutMargins.top,
+                    + l3.bayaMargins.top,
                 width: layoutRect.width - l3.horizontalMargins,
                 height: availableSideLength - l3.verticalMargins))
     }
@@ -482,36 +482,36 @@ class BayaEqualSegmentsTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRectTooSmall.origin.x + l1.layoutMargins.left,
-                y: layoutRectTooSmall.origin.y + l1.layoutMargins.top,
+                x: layoutRectTooSmall.origin.x + l1.bayaMargins.left,
+                y: layoutRectTooSmall.origin.y + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height))
         XCTAssertEqual(
             l2.frame,
             CGRect(
-                x: layoutRectTooSmall.origin.x + l2.layoutMargins.left,
+                x: layoutRectTooSmall.origin.x + l2.bayaMargins.left,
                 y: layoutRectTooSmall.origin.y
                     + availableSideLength
                     + spacing
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
         XCTAssertEqual(
             l3.frame,
             CGRect(
-                x: layoutRectTooSmall.origin.x + l3.layoutMargins.left,
+                x: layoutRectTooSmall.origin.x + l3.bayaMargins.left,
                 y: layoutRectTooSmall.origin.y
                     + availableSideLength * 2
                     + spacing * 2
-                    + l3.layoutMargins.top,
+                    + l3.bayaMargins.top,
                 width: l3.width,
                 height: l3.height))
     }
 
     func testVerticalSmallEnforcedFrameMatchingParent() {
-        l1 = TestLayoutable(sideLength: 30, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 60, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 90, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 30, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 60, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 90, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         var layout = [l1, l2, l3]
             .layoutAsEqualSegments(
                 orientation: .vertical,
@@ -528,28 +528,28 @@ class BayaEqualSegmentsTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRectTooSmall.origin.x + l1.layoutMargins.left,
-                y: layoutRectTooSmall.origin.y + l1.layoutMargins.top,
+                x: layoutRectTooSmall.origin.x + l1.bayaMargins.left,
+                y: layoutRectTooSmall.origin.y + l1.bayaMargins.top,
                 width: maxWidth - l1.horizontalMargins,
                 height: availableSideLength - l1.verticalMargins))
         XCTAssertEqual(
             l2.frame,
             CGRect(
-                x: layoutRectTooSmall.origin.x + l2.layoutMargins.left,
+                x: layoutRectTooSmall.origin.x + l2.bayaMargins.left,
                 y: layoutRectTooSmall.origin.y
                     + availableSideLength
                     + spacing
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: maxWidth - l2.horizontalMargins,
                 height: availableSideLength - l1.verticalMargins))
         XCTAssertEqual(
             l3.frame,
             CGRect(
-                x: layoutRectTooSmall.origin.x + l3.layoutMargins.left,
+                x: layoutRectTooSmall.origin.x + l3.bayaMargins.left,
                 y: layoutRectTooSmall.origin.y
                     + availableSideLength * 2
                     + spacing * 2
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: maxWidth - l3.horizontalMargins,
                 height: availableSideLength - l3.verticalMargins))
     }
@@ -615,7 +615,7 @@ class BayaEqualSegmentsTests: XCTestCase {
 }
 
 private class AnotherOne: BayaLayoutable {
-    var layoutMargins = UIEdgeInsets.zero
+    var bayaMargins = UIEdgeInsets.zero
     var frame = CGRect()
 
     func sizeThatFits(_ size: CGSize) -> CGSize {

--- a/BayaTests/BayaFixedSizeTests.swift
+++ b/BayaTests/BayaFixedSizeTests.swift
@@ -35,8 +35,8 @@ class BayaFixedSizeTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: l.width,
                 height: fixedHeight - l.verticalMargins),
             "frame not matching")
@@ -44,15 +44,15 @@ class BayaFixedSizeTests: XCTestCase {
     
     func testFixedHeightMatchingWidth() {
         let fixedHeight: CGFloat = 100
-        l = TestLayoutable(layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .wrapContent))
+        l = TestLayoutable(bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .wrapContent))
         var layout = l.layoutWithFixedSize(width: nil, height: fixedHeight)
         layout.startLayout(with: layoutRect)
         
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: layoutRect.width - l.horizontalMargins,
                 height: fixedHeight - l.verticalMargins),
             "frame not matching")
@@ -66,8 +66,8 @@ class BayaFixedSizeTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: fixedWidth - l.horizontalMargins,
                 height: l.height),
             "frame not matching")
@@ -75,15 +75,15 @@ class BayaFixedSizeTests: XCTestCase {
     
     func testFixedWidthMatchingHeight() {
         let fixedWidth: CGFloat = 100
-        l = TestLayoutable(layoutModes: BayaLayoutOptions.Modes(width: .wrapContent, height: .matchParent))
+        l = TestLayoutable(bayaModes: BayaLayoutOptions.Modes(width: .wrapContent, height: .matchParent))
         var layout = l.layoutWithFixedSize(width: fixedWidth, height: nil)
         layout.startLayout(with: layoutRect)
         
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: fixedWidth - l.horizontalMargins,
                 height: layoutRect.height - l.verticalMargins),
             "frame not matching")
@@ -97,8 +97,8 @@ class BayaFixedSizeTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: fixedSize.width - l.horizontalMargins,
                 height: fixedSize.height - l.verticalMargins),
             "frame not matching")

--- a/BayaTests/BayaFlexibleContentTests.swift
+++ b/BayaTests/BayaFlexibleContentTests.swift
@@ -46,7 +46,7 @@ class BayaFlexibleContentTests: XCTestCase {
             elementAfter: l3,
             orientation: .horizontal,
             spacing: spacing,
-            layoutMargins: UIEdgeInsets.zero)
+            bayaMargins: UIEdgeInsets.zero)
         let measuredSize = layout.sizeThatFitsWithMargins(layoutRect.size)
 
         let requiredWidth = l1.width
@@ -70,7 +70,7 @@ class BayaFlexibleContentTests: XCTestCase {
             elementAfter: l3,
             orientation: .vertical,
             spacing: spacing,
-            layoutMargins: UIEdgeInsets.zero)
+            bayaMargins: UIEdgeInsets.zero)
         let measuredSize = layout.sizeThatFitsWithMargins(layoutRect.size)
 
         let requiredHeight = l1.height
@@ -94,7 +94,7 @@ class BayaFlexibleContentTests: XCTestCase {
             elementAfter: l3,
             orientation: .horizontal,
             spacing: spacing,
-            layoutMargins: UIEdgeInsets.zero)
+            bayaMargins: UIEdgeInsets.zero)
         layout.startLayout(with: layoutRect)
 
         let requiredWidth = l1.width
@@ -108,22 +108,22 @@ class BayaFlexibleContentTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRect.minX + l1.layoutMargins.left,
-                y: layoutRect.minY + l1.layoutMargins.top,
+                x: layoutRect.minX + l1.bayaMargins.left,
+                y: layoutRect.minY + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height))
         XCTAssertEqual(
             l3.frame,
             CGRect(
-                x: layoutRect.minX + requiredWidth - l3.width - l3.layoutMargins.right,
-                y: layoutRect.minY + l3.layoutMargins.top,
+                x: layoutRect.minX + requiredWidth - l3.width - l3.bayaMargins.right,
+                y: layoutRect.minY + l3.bayaMargins.top,
                 width: l3.width,
                 height: l3.height))
         XCTAssertEqual(
             l2.frame,
             CGRect(
-                x: layoutRect.minX + l1.width + l1.horizontalMargins + spacing + l2.layoutMargins.left,
-                y: layoutRect.minY + l2.layoutMargins.top,
+                x: layoutRect.minX + l1.width + l1.horizontalMargins + spacing + l2.bayaMargins.left,
+                y: layoutRect.minY + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
     }
@@ -140,9 +140,9 @@ class BayaFlexibleContentTests: XCTestCase {
             l1.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l1.layoutMargins.left,
+                    + l1.bayaMargins.left,
                 y: layoutRect.minY
-                    + l1.layoutMargins.top,
+                    + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height))
         XCTAssertEqual(
@@ -152,9 +152,9 @@ class BayaFlexibleContentTests: XCTestCase {
                     + l1.horizontalMargins
                     + l1.width
                     + spacing
-                    + l2.layoutMargins.left,
+                    + l2.bayaMargins.left,
                 y: layoutRect.minY
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
         XCTAssertEqual(
@@ -162,17 +162,17 @@ class BayaFlexibleContentTests: XCTestCase {
             CGRect(
                 x: layoutRect.maxX
                     - l3.width
-                    - l3.layoutMargins.right,
+                    - l3.bayaMargins.right,
                 y: layoutRect.minY
-                    + l3.layoutMargins.top,
+                    + l3.bayaMargins.top,
                 width: l3.width,
                 height: l3.height))
     }
     
     func testHorizontalMatchParent() {
-        l1 = TestLayoutable(sideLength: 40, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 60, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 100, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 40, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 60, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 100, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         
         var layout = l2.layoutFlexible(
             elementBefore: l1,
@@ -196,8 +196,8 @@ class BayaFlexibleContentTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRect.minX + l1.layoutMargins.left,
-                y: layoutRect.minY + l1.layoutMargins.top,
+                x: layoutRect.minX + l1.bayaMargins.left,
+                y: layoutRect.minY + l1.bayaMargins.top,
                 width: l1.width,
                 height: maxHeight - l1.verticalMargins))
         XCTAssertEqual(
@@ -206,7 +206,7 @@ class BayaFlexibleContentTests: XCTestCase {
                     + l1.width
                     + l1.horizontalMargins
                     + spacing
-                    + l2.layoutMargins.left,
+                    + l2.bayaMargins.left,
                 y: layoutRect.minY,
                 width: l2.width,
                 height: maxHeight - l2.verticalMargins))
@@ -215,17 +215,17 @@ class BayaFlexibleContentTests: XCTestCase {
                 x: layoutRect.minX
                     + requiredWidth
                     - l3.width
-                    - l3.layoutMargins.right,
+                    - l3.bayaMargins.right,
                 y: layoutRect.minY
-                    + l3.layoutMargins.top,
+                    + l3.bayaMargins.top,
                 width: l3.width,
                 height: maxHeight - l3.verticalMargins))
     }
     
     func testHorizontalLargeFrameMatchParent() {
-        l1 = TestLayoutable(sideLength: 40, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 70, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 100, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 40, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 70, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 100, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         
         var layout = l2.layoutFlexible(
             elementBefore: l1,
@@ -238,9 +238,9 @@ class BayaFlexibleContentTests: XCTestCase {
             l1.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l1.layoutMargins.left,
+                    + l1.bayaMargins.left,
                 y: layoutRect.minY
-                    + l1.layoutMargins.top,
+                    + l1.bayaMargins.top,
                 width: l1.width,
                 height: layoutRect.height
                     - l1.verticalMargins))
@@ -251,9 +251,9 @@ class BayaFlexibleContentTests: XCTestCase {
                     + l1.horizontalMargins
                     + l1.width
                     + spacing
-                    + l2.layoutMargins.left,
+                    + l2.bayaMargins.left,
                 y: layoutRect.minY
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: layoutRect.width
                     - l1.width
                     - l1.horizontalMargins
@@ -269,9 +269,9 @@ class BayaFlexibleContentTests: XCTestCase {
             CGRect(
                 x: layoutRect.maxX
                     - l3.width
-                    - l3.layoutMargins.right,
+                    - l3.bayaMargins.right,
                 y: layoutRect.minY
-                    + l3.layoutMargins.top,
+                    + l3.bayaMargins.top,
                 width: l3.width,
                 height: layoutRect.height
                     - l3.verticalMargins))
@@ -283,7 +283,7 @@ class BayaFlexibleContentTests: XCTestCase {
             elementAfter: l3,
             orientation: .vertical,
             spacing: spacing,
-            layoutMargins: UIEdgeInsets.zero)
+            bayaMargins: UIEdgeInsets.zero)
         layout.startLayout(with: layoutRect)
 
         let requiredHeight = l1.height
@@ -297,22 +297,22 @@ class BayaFlexibleContentTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRect.minX + l1.layoutMargins.left,
-                y: layoutRect.minY + l1.layoutMargins.top,
+                x: layoutRect.minX + l1.bayaMargins.left,
+                y: layoutRect.minY + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height))
         XCTAssertEqual(
             l3.frame,
             CGRect(
-                x: layoutRect.minX + l3.layoutMargins.left,
-                y: layoutRect.minY + requiredHeight - l3.height - l3.layoutMargins.bottom,
+                x: layoutRect.minX + l3.bayaMargins.left,
+                y: layoutRect.minY + requiredHeight - l3.height - l3.bayaMargins.bottom,
                 width: l3.width,
                 height: l3.height))
         XCTAssertEqual(
             l2.frame,
             CGRect(
-                x: layoutRect.minX + l2.layoutMargins.left,
-                y: layoutRect.minY + l1.height + l1.verticalMargins + spacing + l2.layoutMargins.top,
+                x: layoutRect.minX + l2.bayaMargins.left,
+                y: layoutRect.minY + l1.height + l1.verticalMargins + spacing + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
     }
@@ -329,39 +329,39 @@ class BayaFlexibleContentTests: XCTestCase {
             l1.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l1.layoutMargins.left,
+                    + l1.bayaMargins.left,
                 y: layoutRect.minY
-                    + l1.layoutMargins.top,
+                    + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height))
         XCTAssertEqual(
             l2.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l2.layoutMargins.left,
+                    + l2.bayaMargins.left,
                 y: layoutRect.minY
                     + l1.verticalMargins
                     + l1.height
                     + spacing
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
         XCTAssertEqual(
             l3.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l3.layoutMargins.left,
+                    + l3.bayaMargins.left,
                 y: layoutRect.maxY
                     - l3.height
-                    - l3.layoutMargins.bottom,
+                    - l3.bayaMargins.bottom,
                 width: l3.width,
                 height: l3.height))
     }
     
     func testVerticalMatchParent() {
-        l1 = TestLayoutable(sideLength: 40, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 70, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 100, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 40, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 70, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 100, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         
         var layout = l2.layoutFlexible(
             elementBefore: l1,
@@ -385,9 +385,9 @@ class BayaFlexibleContentTests: XCTestCase {
             l1.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l1.layoutMargins.left,
+                    + l1.bayaMargins.left,
                 y: layoutRect.minY
-                    + l1.layoutMargins.top,
+                    + l1.bayaMargins.top,
                 width: maxWidth
                     - l1.horizontalMargins,
                 height: l1.height))
@@ -395,11 +395,11 @@ class BayaFlexibleContentTests: XCTestCase {
             l3.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l3.layoutMargins.left,
+                    + l3.bayaMargins.left,
                 y: layoutRect.minY
                     + requiredHeight
                     - l3.height
-                    - l3.layoutMargins.bottom,
+                    - l3.bayaMargins.bottom,
                 width: maxWidth
                     - l3.horizontalMargins,
                 height: l3.height))
@@ -407,21 +407,21 @@ class BayaFlexibleContentTests: XCTestCase {
             l2.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l2.layoutMargins.left,
+                    + l2.bayaMargins.left,
                 y: layoutRect.minY
                     + l1.height
                     + l1.verticalMargins
                     + spacing
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: maxWidth
                     - l2.horizontalMargins,
                 height: l2.height))
     }
     
     func testVerticalLargeFrameMatchParent() {
-        l1 = TestLayoutable(sideLength: 40, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 70, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 100, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 40, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 70, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 100, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         
         var layout = l2.layoutFlexible(
             elementBefore: l1,
@@ -434,9 +434,9 @@ class BayaFlexibleContentTests: XCTestCase {
             l1.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l1.layoutMargins.left,
+                    + l1.bayaMargins.left,
                 y: layoutRect.minY
-                    + l1.layoutMargins.top,
+                    + l1.bayaMargins.top,
                 width: layoutRect.width
                     - l1.horizontalMargins,
                 height: l1.height))
@@ -444,12 +444,12 @@ class BayaFlexibleContentTests: XCTestCase {
             l2.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l2.layoutMargins.left,
+                    + l2.bayaMargins.left,
                 y: layoutRect.minY
                     + l1.height
                     + l1.verticalMargins
                     + spacing
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: layoutRect.width
                     - l2.horizontalMargins,
                 height: layoutRect.height
@@ -463,10 +463,10 @@ class BayaFlexibleContentTests: XCTestCase {
             l3.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l3.layoutMargins.right,
+                    + l3.bayaMargins.right,
                 y: layoutRect.maxY
                     - l3.height
-                    - l3.layoutMargins.bottom,
+                    - l3.bayaMargins.bottom,
                 width: layoutRect.width
                     - l3.horizontalMargins,
                 height: l3.height))
@@ -478,14 +478,14 @@ class BayaFlexibleContentTests: XCTestCase {
             elementAfter: nil,
             orientation: .horizontal,
             spacing: spacing,
-            layoutMargins: UIEdgeInsets.zero)
+            bayaMargins: UIEdgeInsets.zero)
         layout.startLayout(with: layoutRect)
 
         XCTAssertEqual(
             l2.frame,
             CGRect(
-                x: layoutRect.minX + l2.layoutMargins.left,
-                y: layoutRect.minY + l2.layoutMargins.top,
+                x: layoutRect.minX + l2.bayaMargins.left,
+                y: layoutRect.minY + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
     }
@@ -496,14 +496,14 @@ class BayaFlexibleContentTests: XCTestCase {
             elementAfter: nil,
             orientation: .vertical,
             spacing: spacing,
-            layoutMargins: UIEdgeInsets.zero)
+            bayaMargins: UIEdgeInsets.zero)
         layout.startLayout(with: layoutRect)
 
         XCTAssertEqual(
             l2.frame,
             CGRect(
-                x: layoutRect.minX + l2.layoutMargins.left,
-                y: layoutRect.minY + l2.layoutMargins.top,
+                x: layoutRect.minX + l2.bayaMargins.left,
+                y: layoutRect.minY + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
     }

--- a/BayaTests/BayaFrameTests.swift
+++ b/BayaTests/BayaFrameTests.swift
@@ -19,17 +19,17 @@ class BayaFrameTests: XCTestCase {
         l2 = TestLayoutable(sideLength: 60)
         l3 = TestLayoutable(sideLength: 90)
 
-        l1.layoutMargins = UIEdgeInsets(
+        l1.bayaMargins = UIEdgeInsets(
             top: 8,
             left: 7,
             bottom: 4,
             right: 3)
-        l2.layoutMargins = UIEdgeInsets(
+        l2.bayaMargins = UIEdgeInsets(
             top: 20,
             left: 50,
             bottom: 23,
             right: 12)
-        l3.layoutMargins = UIEdgeInsets.zero
+        l3.bayaMargins = UIEdgeInsets.zero
     }
 
     override func tearDown() {
@@ -60,35 +60,35 @@ class BayaFrameTests: XCTestCase {
             l2.frame,
             CGRect(
                 x: layoutRect.origin.x
-                    + l2.layoutMargins.left,
+                    + l2.bayaMargins.left,
                 y: layoutRect.origin.y
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
         XCTAssertEqual(
             l1.frame,
             CGRect(
                 x: layoutRect.origin.x
-                    + l1.layoutMargins.left,
+                    + l1.bayaMargins.left,
                 y: layoutRect.origin.y
-                    + l1.layoutMargins.top,
+                    + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height))
         XCTAssertEqual(
             l3.frame,
             CGRect(
                 x: layoutRect.origin.x
-                    + l3.layoutMargins.left,
+                    + l3.bayaMargins.left,
                 y: layoutRect.origin.y
-                    + l3.layoutMargins.top,
+                    + l3.bayaMargins.top,
                 width: l3.width,
                 height: l3.height))
     }
 
     func testSizesMatchingParent() {
-        l1 = TestLayoutable(sideLength: 30, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 60, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 90, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 30, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 60, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 90, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         var layout = [l1, l2, l3]
             .layoutAsFrame()
         let layoutRect = CGRect(
@@ -111,9 +111,9 @@ class BayaFrameTests: XCTestCase {
             l1.frame,
             CGRect(
                 x: layoutRect.origin.x
-                    + l1.layoutMargins.left,
+                    + l1.bayaMargins.left,
                 y: layoutRect.origin.y
-                    + l1.layoutMargins.top,
+                    + l1.bayaMargins.top,
                 width: maxWidth
                     - l1.horizontalMargins,
                 height: maxHeight - l1.verticalMargins))
@@ -121,9 +121,9 @@ class BayaFrameTests: XCTestCase {
             l2.frame,
             CGRect(
                 x: layoutRect.origin.x
-                    + l2.layoutMargins.left,
+                    + l2.bayaMargins.left,
                 y: layoutRect.origin.y
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: maxWidth
                     - l2.horizontalMargins,
                 height: maxHeight
@@ -132,9 +132,9 @@ class BayaFrameTests: XCTestCase {
             l3.frame,
             CGRect(
                 x: layoutRect.origin.x
-                    + l3.layoutMargins.left,
+                    + l3.bayaMargins.left,
                 y: layoutRect.origin.y
-                    + l3.layoutMargins.top,
+                    + l3.bayaMargins.top,
                 width: maxWidth
                     - l3.horizontalMargins,
                 height: maxHeight

--- a/BayaTests/BayaGravityTests.swift
+++ b/BayaTests/BayaGravityTests.swift
@@ -129,8 +129,8 @@ class BayaGravityTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: l.width,
                 height: l.height),
             "frame not matching")
@@ -144,7 +144,7 @@ class BayaGravityTests: XCTestCase {
             l.frame,
             CGRect(
                 x: layoutRect.midX - l.width / 2,
-                y: layoutRect.minY + l.layoutMargins.top,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: l.width,
                 height: l.height),
             "frame not matching")
@@ -157,8 +157,8 @@ class BayaGravityTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.maxX - l.width - l.layoutMargins.right,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.maxX - l.width - l.bayaMargins.right,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: l.width,
                 height: l.height),
             "frame not matching")
@@ -172,7 +172,7 @@ class BayaGravityTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
+                x: layoutRect.minX + l.bayaMargins.left,
                 y: layoutRect.midY - l.height / 2,
                 width: l.width,
                 height: l.height),
@@ -200,7 +200,7 @@ class BayaGravityTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.maxX - l.width - l.layoutMargins.right,
+                x: layoutRect.maxX - l.width - l.bayaMargins.right,
                 y: layoutRect.midY - l.height / 2,
                 width: l.width,
                 height: l.height),
@@ -214,8 +214,8 @@ class BayaGravityTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.maxY - l.height - l.layoutMargins.bottom,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.maxY - l.height - l.bayaMargins.bottom,
                 width: l.width,
                 height: l.height),
             "frame not matching")
@@ -229,7 +229,7 @@ class BayaGravityTests: XCTestCase {
             l.frame,
             CGRect(
                 x: layoutRect.midX - l.width / 2,
-                y: layoutRect.maxY - l.height - l.layoutMargins.bottom,
+                y: layoutRect.maxY - l.height - l.bayaMargins.bottom,
                 width: l.width,
                 height: l.height),
             "frame not matching")
@@ -242,8 +242,8 @@ class BayaGravityTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.maxX - l.width - l.layoutMargins.right,
-                y: layoutRect.maxY - l.height - l.layoutMargins.bottom,
+                x: layoutRect.maxX - l.width - l.bayaMargins.right,
+                y: layoutRect.maxY - l.height - l.bayaMargins.bottom,
                 width: l.width,
                 height: l.height),
             "frame not matching")

--- a/BayaTests/BayaLinearTests.swift
+++ b/BayaTests/BayaLinearTests.swift
@@ -54,8 +54,8 @@ class BayaLinearTests: XCTestCase {
         XCTAssertEqual(
             l1.frame,
             CGRect(
-                x: layoutRect.origin.x + l1.layoutMargins.left,
-                y: layoutRect.origin.y + l1.layoutMargins.top,
+                x: layoutRect.origin.x + l1.bayaMargins.left,
+                y: layoutRect.origin.y + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height),
             "l1 not matching")
@@ -66,8 +66,8 @@ class BayaLinearTests: XCTestCase {
                     + l1.width
                     + l1.horizontalMargins
                     + spacing
-                    + l2.layoutMargins.left,
-                y: layoutRect.origin.y + l2.layoutMargins.top,
+                    + l2.bayaMargins.left,
+                y: layoutRect.origin.y + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height),
             "l2 not matching")
@@ -81,17 +81,17 @@ class BayaLinearTests: XCTestCase {
                     + l2.width
                     + l2.horizontalMargins
                     + spacing +
-                    l3.layoutMargins.left,
-                y: layoutRect.origin.y + l3.layoutMargins.top,
+                    l3.bayaMargins.left,
+                y: layoutRect.origin.y + l3.bayaMargins.top,
                 width: l3.width,
                 height: l3.height),
             "l3 not matching")
     }
     
     func testHorizontalMatchParent() {
-        l1 = TestLayoutable(sideLength: 30, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 60, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 90, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 30, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 60, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 90, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         var layout = [l1, l2, l3].layoutLinearly(
             orientation: .horizontal,
             spacing: spacing)
@@ -105,9 +105,9 @@ class BayaLinearTests: XCTestCase {
             l1.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l1.layoutMargins.left,
+                    + l1.bayaMargins.left,
                 y: layoutRect.minY
-                    + l1.layoutMargins.top,
+                    + l1.bayaMargins.top,
                 width: l1.width,
                 height: maxHeight - l1.verticalMargins))
         XCTAssertEqual(
@@ -117,9 +117,9 @@ class BayaLinearTests: XCTestCase {
                     + l1.width
                     + l1.horizontalMargins
                     + spacing
-                    + l2.layoutMargins.left,
+                    + l2.bayaMargins.left,
                 y: layoutRect.minY
-                    - l2.layoutMargins.top,
+                    - l2.bayaMargins.top,
                 width: l2.width,
                 height: maxHeight
                     - l2.verticalMargins))
@@ -133,9 +133,9 @@ class BayaLinearTests: XCTestCase {
                     + l2.width
                     + l2.horizontalMargins
                     + spacing
-                    + l3.layoutMargins.left,
+                    + l3.bayaMargins.left,
                 y: layoutRect.minY
-                    + l3.layoutMargins.top,
+                    + l3.bayaMargins.top,
                 width: l3.width,
                 height: maxHeight
                     - l3.verticalMargins))
@@ -151,42 +151,42 @@ class BayaLinearTests: XCTestCase {
             l1.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l1.layoutMargins.left,
+                    + l1.bayaMargins.left,
                 y: layoutRect.minY
-                    + l1.layoutMargins.top,
+                    + l1.bayaMargins.top,
                 width: l1.width,
                 height: l1.height))
         XCTAssertEqual(
             l2.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l2.layoutMargins.left,
+                    + l2.bayaMargins.left,
                 y: layoutRect.minY
                     + l1.verticalMargins
                     + l1.height
                     + spacing
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: l2.width,
                 height: l2.height))
         XCTAssertEqual(
             l3.frame,
             CGRect(
-                x: layoutRect.minX + l3.layoutMargins.left,
+                x: layoutRect.minX + l3.bayaMargins.left,
                 y: layoutRect.minY
                     + l1.height
                     + l1.verticalMargins
                     + l2.height
                     + l2.verticalMargins
-                    + l3.layoutMargins.top
+                    + l3.bayaMargins.top
                     + spacing * 2,
                 width: l3.width,
                 height: l3.height))
     }
     
     func testVerticalMatchParent() {
-        l1 = TestLayoutable(sideLength: 30, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l2 = TestLayoutable(sideLength: 60, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
-        l3 = TestLayoutable(sideLength: 90, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l1 = TestLayoutable(sideLength: 30, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l2 = TestLayoutable(sideLength: 60, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l3 = TestLayoutable(sideLength: 90, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         var layout = [l1, l2, l3].layoutLinearly(
             orientation: .vertical,
             spacing: spacing)
@@ -201,9 +201,9 @@ class BayaLinearTests: XCTestCase {
             l1.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l1.layoutMargins.left,
+                    + l1.bayaMargins.left,
                 y: layoutRect.minY
-                    + l1.layoutMargins.top,
+                    + l1.bayaMargins.top,
                 width: maxWidth
                     - l1.horizontalMargins,
                 height: l1.height))
@@ -211,12 +211,12 @@ class BayaLinearTests: XCTestCase {
             l2.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l2.layoutMargins.left,
+                    + l2.bayaMargins.left,
                 y: layoutRect.minY
                     + l1.verticalMargins
                     + l1.height
                     + spacing
-                    + l2.layoutMargins.top,
+                    + l2.bayaMargins.top,
                 width: maxWidth
                     - l2.horizontalMargins,
                 height: l2.height))
@@ -224,13 +224,13 @@ class BayaLinearTests: XCTestCase {
             l3.frame,
             CGRect(
                 x: layoutRect.minX
-                    + l3.layoutMargins.left,
+                    + l3.bayaMargins.left,
                 y: layoutRect.minY
                     + l1.height
                     + l1.verticalMargins
                     + l2.height
                     + l2.verticalMargins
-                    + l3.layoutMargins.top
+                    + l3.bayaMargins.top
                     + spacing * 2,
                 width: maxWidth
                     - l3.horizontalMargins,
@@ -292,7 +292,7 @@ class BayaLinearTests: XCTestCase {
 }
 
 private class AnotherOne: BayaLayoutable {
-    var layoutMargins = UIEdgeInsets.zero
+    var bayaMargins = UIEdgeInsets.zero
     var frame = CGRect()
 
     func sizeThatFits(_ size: CGSize) -> CGSize {

--- a/BayaTests/BayaMarginsTests.swift
+++ b/BayaTests/BayaMarginsTests.swift
@@ -25,7 +25,7 @@ class BayaMarginsTests: XCTestCase {
     
     func testMeasure() {
         let margins = UIEdgeInsets(top: 6, left: 20, bottom: 18, right: 40)
-        var layout = l.layoutWithMargins(layoutMargins: margins)
+        var layout = l.layoutWithMargins(bayaMargins: margins)
         let fit = layout.sizeThatFits(layoutRect.size)
         
         XCTAssertEqual(
@@ -46,11 +46,11 @@ class BayaMarginsTests: XCTestCase {
     
     func testLayout() {
         let margins = UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
-        var layout = l.layoutWithMargins(layoutMargins: margins)
+        var layout = l.layoutWithMargins(bayaMargins: margins)
         layout.startLayout(with: layoutRect)
         
         XCTAssertEqual(
-            layout.layoutMargins,
+            layout.bayaMargins,
             margins)
         
         XCTAssertEqual(
@@ -67,15 +67,15 @@ class BayaMarginsTests: XCTestCase {
         l = TestLayoutable(
             width: 80,
             height: 60,
-            layoutModes: BayaLayoutOptions.Modes(
+            bayaModes: BayaLayoutOptions.Modes(
                 width: .matchParent,
                 height: .matchParent))
         l.m(1, 2, 3, 4)
-        var layout = l.layoutWithMargins(layoutMargins: margins)
+        var layout = l.layoutWithMargins(bayaMargins: margins)
         layout.startLayout(with: layoutRect)
         
         XCTAssertEqual(
-            layout.layoutMargins,
+            layout.bayaMargins,
             margins)
         
         XCTAssertEqual(

--- a/BayaTests/BayaMatchParentTests.swift
+++ b/BayaTests/BayaMatchParentTests.swift
@@ -30,8 +30,8 @@ class BayaMatchParentTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: layoutRect.width - l.horizontalMargins,
                 height: layoutRect.height - l.verticalMargins),
             "frame not matching")
@@ -44,8 +44,8 @@ class BayaMatchParentTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: layoutRect.width - l.horizontalMargins,
                 height: l.height),
             "frame not matching")
@@ -58,8 +58,8 @@ class BayaMatchParentTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: l.width,
                 height: layoutRect.height - l.verticalMargins),
             "frame not matching")

--- a/BayaTests/BayaOriginResetTests.swift
+++ b/BayaTests/BayaOriginResetTests.swift
@@ -48,18 +48,18 @@ class BayaOriginResetTests: XCTestCase {
     }
     
     func testMemberMirroring() {
-        l = TestLayoutable(layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l = TestLayoutable(bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         var layout = l.layoutResettingOrigin()
         layout.startLayout(with: layoutRect)
         XCTAssertEqual(
-            l.layoutModes.height,
-            layout.layoutModes.height)
+            l.bayaModes.height,
+            layout.bayaModes.height)
         XCTAssertEqual(
-            l.layoutModes.width,
-            layout.layoutModes.width)
+            l.bayaModes.width,
+            layout.bayaModes.width)
         XCTAssertEqual(
-            l.layoutMargins,
-            layout.layoutMargins)
+            l.bayaMargins,
+            layout.bayaMargins)
         XCTAssertEqual(
             l.frame,
             layout.frame)

--- a/BayaTests/BayaPagedScrollTests.swift
+++ b/BayaTests/BayaPagedScrollTests.swift
@@ -74,7 +74,7 @@ class BayaPagedScrollTests: XCTestCase {
     func testHorizontalMatchingParent() {
         l = TestLayoutable(
             sideLength: 50,
-            layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+            bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         l.m(1, 2, 3, 4)
         var layout = l.layoutPagedScrollContent(container: c, pages: pages, spacing: spacing, orientation: .horizontal)
         layout.startLayout(with: layoutRect)
@@ -128,7 +128,7 @@ class BayaPagedScrollTests: XCTestCase {
     func testHorizontalBigEnforcedFrameMatchingParent() {
         l = TestLayoutable(
             sideLength: 50,
-            layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+            bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         l.m(1, 2, 3, 4)
 
         var layout = l.layoutPagedScrollContent(container: c, pages: pages, spacing: spacing, orientation: .horizontal)
@@ -183,7 +183,7 @@ class BayaPagedScrollTests: XCTestCase {
     func testHorizontalSmallEnforcedFrameMatchingParent() {
         l = TestLayoutable(
             sideLength: 50,
-            layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+            bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         l.m(1, 2, 3, 4)
         
         var layout = l.layoutPagedScrollContent(container: c, pages: pages, spacing: spacing, orientation: .horizontal)
@@ -238,7 +238,7 @@ class BayaPagedScrollTests: XCTestCase {
     func testVerticalMatchingParent() {
         l = TestLayoutable(
             sideLength: 50,
-            layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+            bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         l.m(1, 2, 3, 4)
         var layout = l.layoutPagedScrollContent(container: c, pages: pages, spacing: spacing, orientation: .vertical)
         layout.startLayout(with: layoutRect)
@@ -292,7 +292,7 @@ class BayaPagedScrollTests: XCTestCase {
     func testVerticalBigEnforcedFrameMatchingParent() {
         l = TestLayoutable(
             sideLength: 50,
-            layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+            bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         l.m(1, 2, 3, 4)
         
         var layout = l.layoutPagedScrollContent(container: c, pages: pages, spacing: spacing, orientation: .vertical)
@@ -347,7 +347,7 @@ class BayaPagedScrollTests: XCTestCase {
     func testVerticalSmallEnforcedFrameMatchingParent() {
         l = TestLayoutable(
             sideLength: 50,
-            layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+            bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         l.m(1, 2, 3, 4)
         
         var layout = l.layoutPagedScrollContent(container: c, pages: pages, spacing: spacing, orientation: .vertical)

--- a/BayaTests/BayaProportionalSizeTests.swift
+++ b/BayaTests/BayaProportionalSizeTests.swift
@@ -67,8 +67,8 @@ class BayaProportionalSizeTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: (layoutRect.width - l.horizontalMargins) * widthFactor,
                 height: l.height))
     }
@@ -77,7 +77,7 @@ class BayaProportionalSizeTests: XCTestCase {
         l = TestLayoutable(
             width: 80,
             height: 90,
-            layoutModes: BayaLayoutOptions.Modes(
+            bayaModes: BayaLayoutOptions.Modes(
                 width: .matchParent,
                 height: .matchParent))
         let widthFactor: CGFloat = 13/15
@@ -87,8 +87,8 @@ class BayaProportionalSizeTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: (layoutRect.width - l.horizontalMargins) * widthFactor,
                 height: layoutRect.height - l.verticalMargins))
     }
@@ -101,8 +101,8 @@ class BayaProportionalSizeTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: l.width,
                 height: (layoutRect.height - l.verticalMargins) * heightFactor))
     }
@@ -111,7 +111,7 @@ class BayaProportionalSizeTests: XCTestCase {
         l = TestLayoutable(
             width: 80,
             height: 90,
-            layoutModes: BayaLayoutOptions.Modes(
+            bayaModes: BayaLayoutOptions.Modes(
                 width: .matchParent,
                 height: .matchParent))
         let heightFactor: CGFloat = 3/5
@@ -121,8 +121,8 @@ class BayaProportionalSizeTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: layoutRect.width - l.horizontalMargins,
                 height: (layoutRect.height - l.verticalMargins) * heightFactor))
     }
@@ -136,8 +136,8 @@ class BayaProportionalSizeTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: (layoutRect.width - l.horizontalMargins) * widthFactor,
                 height: (layoutRect.height - l.verticalMargins) * heightFactor))
     }
@@ -151,8 +151,8 @@ class BayaProportionalSizeTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: (layoutRect.width - l.horizontalMargins),
                 height: (layoutRect.height - l.verticalMargins)))
     }
@@ -198,7 +198,7 @@ class BayaProportionalSizeTests: XCTestCase {
         l = TestLayoutable(
             width: 100,
             height: 133,
-            layoutModes: BayaLayoutOptions.Modes(
+            bayaModes: BayaLayoutOptions.Modes(
                 width: .matchParent,
                 height: .matchParent))
         let widthFactor: CGFloat = 1/3

--- a/BayaTests/BayaScrollTests.swift
+++ b/BayaTests/BayaScrollTests.swift
@@ -62,15 +62,15 @@ class BayaScrollTests: XCTestCase {
         XCTAssertEqual(
             content.frame,
             CGRect(
-                x: container.bounds.minX + content.layoutMargins.left,
-                y: container.bounds.minY + content.layoutMargins.top,
+                x: container.bounds.minX + content.bayaMargins.left,
+                y: container.bounds.minY + content.bayaMargins.top,
                 width: content.width,
                 height: content.height))
         XCTAssertEqual(
             container.frame,
             CGRect(
-                x: layoutRect.minX + container.layoutMargins.left,
-                y: layoutRect.minY + container.layoutMargins.top,
+                x: layoutRect.minX + container.bayaMargins.left,
+                y: layoutRect.minY + container.bayaMargins.top,
                 width: layoutRect.width - container.horizontalMargins,
                 height: layoutRect.height - container.verticalMargins))
         XCTAssertEqual(
@@ -89,15 +89,15 @@ class BayaScrollTests: XCTestCase {
         XCTAssertEqual(
             content.frame,
             CGRect(
-                x: container.bounds.minX + content.layoutMargins.left,
-                y: container.bounds.minY + content.layoutMargins.top,
+                x: container.bounds.minX + content.bayaMargins.left,
+                y: container.bounds.minY + content.bayaMargins.top,
                 width: content.width,
                 height: content.height))
         XCTAssertEqual(
             container.frame,
             CGRect(
-                x: layoutRect.minX + container.layoutMargins.left,
-                y: layoutRect.minY + container.layoutMargins.top,
+                x: layoutRect.minX + container.bayaMargins.left,
+                y: layoutRect.minY + container.bayaMargins.top,
                 width: content.widthWithMargins,
                 height: content.heightWithMargins))
         XCTAssertEqual(
@@ -108,7 +108,7 @@ class BayaScrollTests: XCTestCase {
     }
     
     func testHorizontalSmallContentMatchParent() {
-        content = TestLayoutable(sideLength: 80, layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        content = TestLayoutable(sideLength: 80, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         content.m(1, 2, 3, 4)
         var layout = content.layoutScrollContent(container: container, orientation: .horizontal)
         layout.startLayout(with: layoutRect)
@@ -116,15 +116,15 @@ class BayaScrollTests: XCTestCase {
         XCTAssertEqual(
             content.frame,
             CGRect(
-                x: container.bounds.minX + content.layoutMargins.left,
-                y: container.bounds.minY + content.layoutMargins.top,
+                x: container.bounds.minX + content.bayaMargins.left,
+                y: container.bounds.minY + content.bayaMargins.top,
                 width: layoutRect.width - content.horizontalMargins - container.horizontalMargins,
                 height: layoutRect.height - content.verticalMargins - container.verticalMargins))
         XCTAssertEqual(
             container.frame,
             CGRect(
-                x: layoutRect.minX + container.layoutMargins.left,
-                y: layoutRect.minY + container.layoutMargins.top,
+                x: layoutRect.minX + container.bayaMargins.left,
+                y: layoutRect.minY + container.bayaMargins.top,
                 width: layoutRect.width - container.horizontalMargins,
                 height: layoutRect.height - container.verticalMargins))
         XCTAssertEqual(
@@ -143,15 +143,15 @@ class BayaScrollTests: XCTestCase {
         XCTAssertEqual(
             content.frame,
             CGRect(
-                x: container.bounds.minX + content.layoutMargins.left,
-                y: container.bounds.minY + content.layoutMargins.top,
+                x: container.bounds.minX + content.bayaMargins.left,
+                y: container.bounds.minY + content.bayaMargins.top,
                 width: content.width,
                 height: content.height))
         XCTAssertEqual(
             container.frame,
             CGRect(
-                x: layoutRect.minX + container.layoutMargins.left,
-                y: layoutRect.minY + container.layoutMargins.top,
+                x: layoutRect.minX + container.bayaMargins.left,
+                y: layoutRect.minY + container.bayaMargins.top,
                 width: layoutRect.width - container.horizontalMargins,
                 height: layoutRect.height - container.verticalMargins))
         XCTAssertEqual(
@@ -170,15 +170,15 @@ class BayaScrollTests: XCTestCase {
         XCTAssertEqual(
             content.frame,
             CGRect(
-                x: container.bounds.minX + content.layoutMargins.left,
-                y: container.bounds.minY + content.layoutMargins.top,
+                x: container.bounds.minX + content.bayaMargins.left,
+                y: container.bounds.minY + content.bayaMargins.top,
                 width: content.width,
                 height: content.height))
         XCTAssertEqual(
             container.frame,
             CGRect(
-                x: layoutRect.minX + container.layoutMargins.left,
-                y: layoutRect.minY + container.layoutMargins.top,
+                x: layoutRect.minX + container.bayaMargins.left,
+                y: layoutRect.minY + container.bayaMargins.top,
                 width: content.width + content.horizontalMargins,
                 height: content.height + content.verticalMargins))
         XCTAssertEqual(
@@ -191,7 +191,7 @@ class BayaScrollTests: XCTestCase {
     func testVerticalSmallContentMatchParent() {
         content = TestLayoutable(
             sideLength: 100,
-            layoutModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+            bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
         content.m(1, 2, 3, 4)
         var layout = content.layoutScrollContent(container: container, orientation: .vertical)
         layout.startLayout(with: layoutRect)
@@ -199,15 +199,15 @@ class BayaScrollTests: XCTestCase {
         XCTAssertEqual(
             content.frame,
             CGRect(
-                x: container.bounds.minX + content.layoutMargins.left,
-                y: container.bounds.minY + content.layoutMargins.top,
+                x: container.bounds.minX + content.bayaMargins.left,
+                y: container.bounds.minY + content.bayaMargins.top,
                 width: layoutRect.width - container.horizontalMargins - content.horizontalMargins,
                 height: layoutRect.height - container.verticalMargins - content.verticalMargins))
         XCTAssertEqual(
             container.frame,
             CGRect(
-                x: layoutRect.minX + container.layoutMargins.left,
-                y: layoutRect.minY + container.layoutMargins.top,
+                x: layoutRect.minX + container.bayaMargins.left,
+                y: layoutRect.minY + container.bayaMargins.top,
                 width: layoutRect.width - container.horizontalMargins,
                 height: layoutRect.height - container.verticalMargins))
         XCTAssertEqual(
@@ -231,15 +231,15 @@ class BayaScrollTests: XCTestCase {
         XCTAssertEqual(
             content.frame,
             CGRect(
-                x: container.bounds.minX + content.layoutMargins.left,
-                y: container.bounds.minY + content.layoutMargins.top,
+                x: container.bounds.minX + content.bayaMargins.left,
+                y: container.bounds.minY + content.bayaMargins.top,
                 width: content.width,
                 height: content.height))
         XCTAssertEqual(
             container.frame,
             CGRect(
-                x: layoutRect.minX + container.layoutMargins.left,
-                y: layoutRect.minY + container.layoutMargins.top,
+                x: layoutRect.minX + container.bayaMargins.left,
+                y: layoutRect.minY + container.bayaMargins.top,
                 width: layoutRect.width - container.horizontalMargins,
                 height: layoutRect.height - container.verticalMargins))
         XCTAssertEqual(
@@ -263,15 +263,15 @@ class BayaScrollTests: XCTestCase {
         XCTAssertEqual(
             content.frame,
             CGRect(
-                x: container.bounds.minX + content.layoutMargins.left,
-                y: container.bounds.minY + content.layoutMargins.top,
+                x: container.bounds.minX + content.bayaMargins.left,
+                y: container.bounds.minY + content.bayaMargins.top,
                 width: content.width,
                 height: content.height))
         XCTAssertEqual(
             container.frame,
             CGRect(
-                x: layoutRect.minX + container.layoutMargins.left,
-                y: layoutRect.minY + container.layoutMargins.top,
+                x: layoutRect.minX + container.bayaMargins.left,
+                y: layoutRect.minY + container.bayaMargins.top,
                 width: layoutRect.width - container.horizontalMargins,
                 height: layoutRect.height - container.verticalMargins))
         XCTAssertEqual(
@@ -295,15 +295,15 @@ class BayaScrollTests: XCTestCase {
         XCTAssertEqual(
             content.frame,
             CGRect(
-                x: container.bounds.minX + content.layoutMargins.left,
-                y: container.bounds.minY + content.layoutMargins.top,
+                x: container.bounds.minX + content.bayaMargins.left,
+                y: container.bounds.minY + content.bayaMargins.top,
                 width: content.width,
                 height: content.height))
         XCTAssertEqual(
             container.frame,
             CGRect(
-                x: layoutRect.minX + container.layoutMargins.left,
-                y: layoutRect.minY + container.layoutMargins.top,
+                x: layoutRect.minX + container.bayaMargins.left,
+                y: layoutRect.minY + container.bayaMargins.top,
                 width: layoutRect.width - container.horizontalMargins,
                 height: layoutRect.height - container.verticalMargins))
         XCTAssertEqual(
@@ -327,15 +327,15 @@ class BayaScrollTests: XCTestCase {
         XCTAssertEqual(
             content.frame,
             CGRect(
-                x: container.bounds.minX + content.layoutMargins.left,
-                y: container.bounds.minY + content.layoutMargins.top,
+                x: container.bounds.minX + content.bayaMargins.left,
+                y: container.bounds.minY + content.bayaMargins.top,
                 width: content.width,
                 height: content.height))
         XCTAssertEqual(
             container.frame,
             CGRect(
-                x: layoutRect.minX + container.layoutMargins.left,
-                y: layoutRect.minY + container.layoutMargins.top,
+                x: layoutRect.minX + container.bayaMargins.left,
+                y: layoutRect.minY + container.bayaMargins.top,
                 width: layoutRect.width - container.horizontalMargins,
                 height: layoutRect.height - container.verticalMargins))
         XCTAssertEqual(

--- a/BayaTests/BayaSquareTests.swift
+++ b/BayaTests/BayaSquareTests.swift
@@ -65,8 +65,8 @@ class BayaSquareTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: layoutRect.width - l.horizontalMargins,
                 height: layoutRect.width - l.horizontalMargins),
             "frame does not match")
@@ -82,8 +82,8 @@ class BayaSquareTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: smallLayoutRect.minX + l.layoutMargins.left,
-                y: smallLayoutRect.minY + l.layoutMargins.top,
+                x: smallLayoutRect.minX + l.bayaMargins.left,
+                y: smallLayoutRect.minY + l.bayaMargins.top,
                 width: smallLayoutRect.width - l.horizontalMargins,
                 height: smallLayoutRect.width - l.horizontalMargins),
             "frame does not match")
@@ -95,8 +95,8 @@ class BayaSquareTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: layoutRect.height - l.verticalMargins,
                 height: layoutRect.height - l.verticalMargins),
             "frame does not match")
@@ -112,8 +112,8 @@ class BayaSquareTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: smallLayoutRect.minX + l.layoutMargins.left,
-                y: smallLayoutRect.minY + l.layoutMargins.top,
+                x: smallLayoutRect.minX + l.bayaMargins.left,
+                y: smallLayoutRect.minY + l.bayaMargins.top,
                 width: smallLayoutRect.height - l.verticalMargins,
                 height: smallLayoutRect.height - l.verticalMargins),
             "frame does not match")
@@ -127,8 +127,8 @@ class BayaSquareTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: bigSide,
                 height: bigSide),
             "frame does not match")
@@ -138,7 +138,7 @@ class BayaSquareTests: XCTestCase {
         l = TestLayoutable(
             width: 60,
             height: 20,
-            layoutModes: BayaLayoutOptions.Modes(
+            bayaModes: BayaLayoutOptions.Modes(
                 width: .matchParent,
                 height: .matchParent))
         var layout = l.layoutAsSquare()
@@ -148,8 +148,8 @@ class BayaSquareTests: XCTestCase {
         XCTAssertEqual(
             l.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: bigSide,
                 height: bigSide),
             "frame does not match when using matchParent")
@@ -158,7 +158,7 @@ class BayaSquareTests: XCTestCase {
         let l2 = TestLayoutable(
             width: 70,
             height: 10,
-            layoutModes: BayaLayoutOptions.Modes(
+            bayaModes: BayaLayoutOptions.Modes(
                 width: .wrapContent,
                 height: .wrapContent))
         var layout2 = l2.layoutAsSquare()
@@ -168,8 +168,8 @@ class BayaSquareTests: XCTestCase {
         XCTAssertEqual(
             l2.frame,
             CGRect(
-                x: layoutRect.minX + l.layoutMargins.left,
-                y: layoutRect.minY + l.layoutMargins.top,
+                x: layoutRect.minX + l.bayaMargins.left,
+                y: layoutRect.minY + l.bayaMargins.top,
                 width: bigSide2,
                 height: bigSide2),
             "Frames using matchParent and wrapContent are different but should be the same")

--- a/BayaTests/TestLayoutable.swift
+++ b/BayaTests/TestLayoutable.swift
@@ -9,23 +9,23 @@ import Baya
 class TestLayoutable: BayaLayoutable {
     let width: CGFloat
     let height: CGFloat
-    let layoutModes: BayaLayoutOptions.Modes
+    let bayaModes: BayaLayoutOptions.Modes
     var frame = CGRect()
-    var layoutMargins = UIEdgeInsets.zero
+    var bayaMargins = UIEdgeInsets.zero
     
     init(
         width: CGFloat = 50,
         height: CGFloat = 50,
-        layoutModes: BayaLayoutOptions.Modes? = nil) {
+        bayaModes: BayaLayoutOptions.Modes? = nil) {
         self.width = width
         self.height = height
-        self.layoutModes = layoutModes ?? BayaLayoutOptions.Modes(width: .wrapContent, height: .wrapContent)
+        self.bayaModes = bayaModes ?? BayaLayoutOptions.Modes(width: .wrapContent, height: .wrapContent)
     }
     
     convenience init(
         sideLength: CGFloat,
-        layoutModes: BayaLayoutOptions.Modes? = nil) {
-        self.init(width: sideLength, height: sideLength, layoutModes: layoutModes)
+        bayaModes: BayaLayoutOptions.Modes? = nil) {
+        self.init(width: sideLength, height: sideLength, bayaModes: bayaModes)
     }
 
     func sizeThatFits(_ size: CGSize) -> CGSize {
@@ -39,7 +39,7 @@ class TestLayoutable: BayaLayoutable {
     }
 
     func m(_ top: CGFloat, _ left: CGFloat, _ bottom: CGFloat, _ right: CGFloat) {
-        layoutMargins = UIEdgeInsets(
+        bayaMargins = UIEdgeInsets(
             top: top,
             left: left,
             bottom: bottom,


### PR DESCRIPTION
iPhone X's safe area management modifies `layoutMargin`s of `UIView`s that enter the edge of the screen. This change prevents these auto-adjustments from affecting your layout.

- `layoutMargins` renamed to `bayaMargins`, now separated from `UIKit`
- `layoutModes` renamed to `bayaModes`

Also removed a few default values from constructors.
