### PR TITLE
Feature propotional measurement

### DIFF
--- a/Baya/layouts/BayaProportionalSizeLayout.swift
+++ b/Baya/layouts/BayaProportionalSizeLayout.swift
@@ -64,7 +64,10 @@ public struct BayaProportionalSizeLayout: BayaLayout {
     }
     
     private mutating func calculateMeasure(_ size: CGSize) -> CGSize {
-        let fit = element.sizeThatFits(size)
+        let fitSize = CGSize(
+            width: widthFactor != nil ? size.width * widthFactor! : size.width,
+            height: heightFactor != nil ? size.height * heightFactor! : size.height)
+        let fit = element.sizeThatFits(fitSize)
         return CGSize(
             width: widthFactor != nil ? size.width * widthFactor! : fit.width,
             height: heightFactor != nil ? size.height * heightFactor! : fit.height)

--- a/BayaTests/BayaProportionalSizeTests.swift
+++ b/BayaTests/BayaProportionalSizeTests.swift
@@ -212,4 +212,44 @@ class BayaProportionalSizeTests: XCTestCase {
                 width: layoutRect.width * widthFactor,
                 height: layoutRect.height * heightFactor))
     }
+    
+    func testProportionalMeasurementHorizontal() {
+        l = ProportionalMeasureSquareTestLayoutable(squaredBasedOn: .horizontal)
+        var layout = l.layoutWithPortion(ofWidth: 0.6)
+        let measure = layout.sizeThatFits(layoutRect.size)
+        
+        XCTAssertEqual(
+            measure.height,
+            layoutRect.width * 0.6,
+            "unexpected width")
+    }
+    
+    func testProportionalMeasurementVertical() {
+        l = ProportionalMeasureSquareTestLayoutable(squaredBasedOn: .vertical)
+        var layout = l.layoutWithPortion(ofHeight: 0.36)
+        let measure = layout.sizeThatFits(layoutRect.size)
+        
+        XCTAssertEqual(
+            measure.width,
+            layoutRect.height * 0.36,
+            "unexpected height")
+    }
+}
+
+class ProportionalMeasureSquareTestLayoutable: TestLayoutable {
+    private let baseSide: BayaLayoutOptions.Orientation
+    
+    init(squaredBasedOn: BayaLayoutOptions.Orientation) {
+        baseSide = squaredBasedOn
+    }
+    
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        switch baseSide {
+        case .horizontal:
+            return CGSize(width: size.width, height: size.width)
+        case .vertical:
+            return CGSize(width: size.height, height: size.height)
+        }
+        
+    }
 }


### PR DESCRIPTION
Measurement of the `BayaProportionalLayout` did measure the child with the input size, not respecting the with and height factors. Layouts that depend on the correct width during measurement (e.g. `BayaSquareLayout`) could not work properly when wrapped with this layout.

The fix is to apply with and height factors before measuring the child layout.