### PR TITLE
Fix frame layout match parent

### DIFF
--- a/Baya/layouts/BayaFrameLayout.swift
+++ b/Baya/layouts/BayaFrameLayout.swift
@@ -29,7 +29,10 @@ public struct BayaFrameLayout: BayaLayout, BayaLayoutIterator {
         let measures = measureIfNecessary(&elements, cache: self.measures, size: frame.size)
         iterate(&elements, measures) {
             e1, e2, e2s in
-            let size = BayaFrameLayout.combineSizeForLayout(for: e2, wrappingSize: e2s, matchingSize: frame.size)
+            let size = BayaFrameLayout.combineSizeForLayout(
+                for: e2,
+                wrappingSize: e2s,
+                matchingSize: frame.size.subtractMargins(ofElement: e2))
             return CGRect(
                 origin: CGPoint(
                     x: frame.minX + e2.bayaMargins.left,

--- a/BayaTests/BayaFrameTests.swift
+++ b/BayaTests/BayaFrameTests.swift
@@ -140,6 +140,26 @@ class BayaFrameTests: XCTestCase {
                 height: maxHeight
                     - l3.verticalMargins))
     }
+    
+    func testMatchingParentWithMargins() {
+        let l = TestLayoutable(sideLength: 90, bayaModes: BayaLayoutOptions.Modes(width: .matchParent, height: .matchParent))
+        l.bayaMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        let layoutRect = CGRect(
+            x: 5,
+            y: 10,
+            width: 300,
+            height: 300)
+        var layout = [l].layoutAsFrame()
+        layout.layoutWith(frame: layoutRect) // Skips the first measure step
+        
+        XCTAssertEqual(
+            l.frame,
+            CGRect(
+                x: 5 + 16,
+                y: 10 + 16,
+                width: layoutRect.width - l.horizontalMargins,
+                height: layoutRect.height - l.verticalMargins))
+    }
 
     func testMeasures() {
         var layout = [l1, l2, l3]


### PR DESCRIPTION
Margin were not subtracted in `layoutWith()` when child element's mode was `matchParent`