### PR TITLE
Fix match parent overrides

### DIFF
--- a/Baya/layouts/BayaMatchParentLayout.swift
+++ b/Baya/layouts/BayaMatchParentLayout.swift
@@ -45,7 +45,7 @@ public extension BayaLayoutable {
             element: self,
             bayaModes: BayaLayoutOptions.Modes(
                 width: .matchParent,
-                height: .wrapContent))
+                height: self.bayaModes.height))
     }
 
     /// Specifies that the element should fill its parent's height instead of using the measured height.
@@ -54,7 +54,7 @@ public extension BayaLayoutable {
         return BayaMatchParentLayout(
             element: self,
             bayaModes: BayaLayoutOptions.Modes(
-                width: .wrapContent,
+                width: self.bayaModes.width,
                 height: .matchParent))
     }
 

--- a/BayaTests/BayaMatchParentTests.swift
+++ b/BayaTests/BayaMatchParentTests.swift
@@ -74,4 +74,34 @@ class BayaMatchParentTests: XCTestCase {
             CGSize(width: l.width, height: l.height),
             "size not matching")
     }
+    
+    func testChildModeNotAffectedByUnrelatedMatchParent() {
+        let l1 = TestLayoutable(
+            bayaModes: BayaLayoutOptions.Modes(
+                width: .matchParent,
+                height: .wrapContent))
+        let l2 = TestLayoutable(
+            bayaModes: BayaLayoutOptions.Modes(
+                width: .wrapContent,
+                height: .matchParent))
+        var layout1 = l1.layoutMatchingParentHeight()
+        var layout2 = l2.layoutMatchingParentWidth()
+        layout1.startLayout(with: layoutRect)
+        layout2.startLayout(with: layoutRect)
+        
+        let expectedRect = CGRect(
+            x: layoutRect.minX + l1.bayaMargins.left,
+            y: layoutRect.minY + l1.bayaMargins.top,
+            width: layoutRect.width - l1.horizontalMargins,
+            height: layoutRect.height - l1.verticalMargins)
+        
+        XCTAssertEqual(
+            l1.frame,
+            expectedRect,
+            "frame not matching for height test")
+        XCTAssertEqual(
+            l2.frame,
+            expectedRect,
+            "frame not matching for width test")
+    }
 }


### PR DESCRIPTION
This would be quick solution for #64 

The `Mode` which should not be affected by calling `layoutMatchingParentHeight()` or `layoutMatchingParentWidth()` is taken from the child element.

A child element which changes `Mode`s after layout creation would break this. I would prefer that over a computed property for `BayaMatchParentLayout`'s `bayaModes` though.